### PR TITLE
feat: add tab navigation to single tile component

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -337,7 +337,7 @@
 }
 
 .tile-selection-single {
-    @apply relative py-4 border-2 cursor-pointer select-none rounded-xl border-theme-primary-100 transition-default;
+    @apply relative py-4 border-2 cursor-pointer select-none rounded-xl border-theme-primary-100 transition-default outline-none focus:ring-2 focus:ring-theme-primary-500;
 }
 
 .tile-selection-option:hover,

--- a/resources/views/inputs/includes/tile-selection-option.blade.php
+++ b/resources/views/inputs/includes/tile-selection-option.blade.php
@@ -10,7 +10,10 @@
     <label
         dusk="tile-selection-label-{{ $option['id'] }}"
         for="{{ $id.'-'.$option['id'] }}"
-        wire:key="tile-selection-option-{{ $id.'-'.$option['id'] }}"
+        @if ($single)
+            tabindex="0"
+            x-on:keydown.space.prevent="$event.target.querySelector('input').click()"
+        @endif
         @class([
             'tile-selection-single' => $single,
             'tile-selection-option' => ! $single,
@@ -26,6 +29,7 @@
     >
         @if ($single)
             <input
+                tabindex="-1"
                 id="{{ $id.'-'.$option['id'] }}"
                 name="{{ $id }}"
                 type="radio"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Replaces this PR https://github.com/ArkEcosystemArchive/laravel-ui/pull/660

https://app.clickup.com/t/1hwy93h

### To test:

- merge this on msq
- recompile assets
- you should be able to navigate to the category tiles with the keyboard
- press space to select an option
- in case you wonder, the enter key doesn't do anything, and you cannot deselect by pressing space two times (same behavior that a native checkbox have)

![image](https://user-images.githubusercontent.com/17262776/135667901-ea8abb30-937e-4a1b-91b6-01e9b747f34c.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [X] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
