### PR TITLE
fix: problem with custom view finder and numbers

### DIFF
--- a/src/CommonMark/View/FileViewFinder.php
+++ b/src/CommonMark/View/FileViewFinder.php
@@ -5,28 +5,57 @@ declare(strict_types=1);
 namespace ARKEcosystem\Foundation\CommonMark\View;
 
 use Illuminate\View\FileViewFinder as Finder;
+use InvalidArgumentException;
 use Spatie\Regex\Regex;
 
 final class FileViewFinder extends Finder
 {
     /**
-     * Get an array of possible view files.
+     * Find the given view in the list of paths.
      *
-     * @param string $name
+     * @param  string  $name
+     * @param  array  $paths
+     * @return string
      *
-     * @return array
+     * @throws \InvalidArgumentException
      */
-    protected function getPossibleViewFiles($name)
+    protected function findInPaths($name, $paths)
     {
-        return array_map(function ($extension) use ($name) : string {
-            // Match number with optional decimals
-            $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
+        // Match number with optional decimals
+        $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
+        $isNumericName = $regex->hasMatch();
 
-            if ($regex->hasMatch()) {
-                $name = rtrim(explode($regex->result(), $name)[0], '.');
+        foreach ((array) $paths as $path) {
+            if ($isNumericName) {
+                $possibleViewFiles = $this->getPossibleViewFilesForNumericName($name, $path);
+            } else {
+                $possibleViewFiles = $this->getPossibleViewFiles($name);
+            }
 
+            foreach ($possibleViewFiles as $file) {
+                if ($this->files->exists($viewPath = $path.'/'.$file)) {
+                    return $viewPath;
+                }
+            }
+        }
 
-                return str_replace('.', '/', $name).'/'.$regex->result().'.'.$extension;
+        throw new InvalidArgumentException("View [{$name}] not found.");
+    }
+
+    protected function getPossibleViewFilesForNumericName(string $name, string $path): array
+    {
+        $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
+
+        return array_map(function ($extension) use ($path, $name, $regex) : string {
+            $name = rtrim(explode($regex->result(), $name)[0], '.');
+
+            $file =  str_replace('.', '/', $name).'/'.$regex->result().'.'.$extension;
+
+            // Only return the file if it exists, that prevents applying this
+            // custom logic to numbers returned from custom render functions
+            // like `src/UserInterface/Components/Number.php`
+            if ($this->files->exists($path.'/'.$file)) {
+                return $file;
             }
 
             return str_replace('.', '/', $name).'.'.$extension;

--- a/src/CommonMark/View/FileViewFinder.php
+++ b/src/CommonMark/View/FileViewFinder.php
@@ -22,7 +22,7 @@ final class FileViewFinder extends Finder
     protected function findInPaths($name, $paths)
     {
         // Match number with optional decimals
-        $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
+        $regex = Regex::match('/\d.\d/', $name);
         $isNumericName = $regex->hasMatch();
 
         foreach ((array) $paths as $path) {
@@ -44,7 +44,7 @@ final class FileViewFinder extends Finder
 
     protected function getPossibleViewFilesForNumericName(string $name, string $path): array
     {
-        $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
+        $regex = Regex::match('/\d.\d/', $name);
 
         return array_map(function ($extension) use ($path, $name, $regex) : string {
             $name = rtrim(explode($regex->result(), $name)[0], '.');

--- a/src/CommonMark/View/FileViewFinder.php
+++ b/src/CommonMark/View/FileViewFinder.php
@@ -19,10 +19,12 @@ final class FileViewFinder extends Finder
     protected function getPossibleViewFiles($name)
     {
         return array_map(function ($extension) use ($name) : string {
-            $regex = Regex::match('/\d.\d/', $name);
+            // Match number with optional decimals
+            $regex = Regex::match('/^\d*(\.\d*)?$/', $name);
 
             if ($regex->hasMatch()) {
                 $name = rtrim(explode($regex->result(), $name)[0], '.');
+
 
                 return str_replace('.', '/', $name).'/'.$regex->result().'.'.$extension;
             }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The `CommonMarkServiceProvider` register a custom ViewFinder that is causing issues on my PR for updating the explorer dependencies and adding foundation (https://github.com/ArkEcosystem/explorer/pull/968)

Basically, it not loads the class-based components until I remove those lines

The custom class is used to handle views that contain a number like, for example (https://ark.dev/docs/core/releases/upgrade/2.4) the problem is that it was creating conflicts with the Number component that also returned a number 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
