### PR TITLE
fix: Livewire not resolving any components during the middleware check for invalid requests

### DIFF
--- a/src/UserInterface/Http/Middlewares/DropInvalidLivewireRequests.php
+++ b/src/UserInterface/Http/Middlewares/DropInvalidLivewireRequests.php
@@ -7,7 +7,7 @@ namespace ARKEcosystem\Foundation\UserInterface\Http\Middlewares;
 use Closure;
 use Illuminate\Http\Request;
 use Livewire\Exceptions\ComponentNotFoundException;
-use Livewire\LivewireManager;
+use Livewire\Livewire;
 
 final class DropInvalidLivewireRequests
 {
@@ -41,7 +41,7 @@ final class DropInvalidLivewireRequests
     private function isValidComponent(string $component) : bool
     {
         try {
-            return app(LivewireManager::class)->getClass($component) !== null;
+            return Livewire::getClass($component) !== null;
         } catch (ComponentNotFoundException $e) {
             return false;
         }

--- a/tests/UserInterface/Livewire/DropInvalidLivewireRequestsTest.php
+++ b/tests/UserInterface/Livewire/DropInvalidLivewireRequestsTest.php
@@ -6,7 +6,7 @@ use ARKEcosystem\Foundation\UserInterface\Http\Middlewares\DropInvalidLivewireRe
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Livewire\Exceptions\ComponentNotFoundException;
-use Livewire\LivewireManager;
+use Livewire\Livewire;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 function mockRequest(string $routeName = 'testing::dummy', array $payload = []) : Request
@@ -49,9 +49,7 @@ it('drops if component is not found', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andThrow(ComponentNotFoundException::class);
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andThrow(ComponentNotFoundException::class);
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -77,9 +75,7 @@ it('drops if fingerprint ID is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -105,9 +101,7 @@ it('drops if fingerprint component name is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -133,9 +127,7 @@ it('drops if fingerprint method is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -161,9 +153,7 @@ it('drops if fingerprint path is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -189,9 +179,7 @@ it('drops if checksum is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');
@@ -217,9 +205,7 @@ it('drops if html hash is missing', function () {
         ],
     ]);
 
-    $this->mock(LivewireManager::class, function ($mock) {
-        $mock->shouldReceive('getClass')->with('dummy-name')->andReturn('done');
-    });
+    Livewire::shouldReceive('getClass')->with('dummy-name')->andReturn('done');
 
     try {
         $response = (new DropInvalidLivewireRequests())->handle($request, fn () => 'Hello world');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

If you manually register a component with `Livewire\Livewire::component('name', MyComponent::class)`, Livewire will not recognize that the component has been registered if you check with `app(LivewireManager::class)->getClass('name')`. However, if checking using the facade `Livewire\Livewire::getClass('name')` it will successfully find that component. Keep in mind that `Livewire\Livewire::class` is just a facade for `Livewire\LivewireManager::class`.

This has produced a bug where middleware to drop requests would fail even if the component is valid, only if the component has been manually registered (i.e. outside of default namespace).

Updated tests accordingly.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
