### PR TITLE
fix: phpstan path configuration

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
     paths:
-        - app
+        - ../../../app
     excludePaths:
     level: 8
     ignoreErrors:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1m1e51v
Since Phpstan configuration is used as a centralized config for all our Laravel based projects, we need to ensure that point to the root project and not to foundation itself.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
