### PR TITLE
fix: rector path configuration

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -8,21 +8,23 @@ use Rector\Set\ValueObject\SetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    $dir = getcwd();
+
     $parameters = $containerConfigurator->parameters();
 
     $parameters->set(Option::PATHS, [
-        __DIR__.'/app',
+        $dir.'/app',
     ]);
     $parameters->set(Option::SKIP, [
-        __DIR__.'/app/Providers',
-        __DIR__.'/app/Exceptions',
+        $dir.'/app/Providers',
+        $dir.'/app/Exceptions',
     ]);
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     $parameters->set(Option::IMPORT_SHORT_CLASSES, true);
     $parameters->set(Option::IMPORT_DOC_BLOCKS, false);
 
-    if (file_exists(getcwd().'/phpstan.neon')) {
-        $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, getcwd().'/phpstan.neon');
+    if (file_exists($dir.'/vendor/arkecosystem/foundation/phpstan.neon')) {
+        $parameters->set(Option::PHPSTAN_FOR_RECTOR_PATH, $dir.'/vendor/arkecosystem/foundation/phpstan.neon');
     }
 
     $containerConfigurator->import(SetList::CARBON_2);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1m1e6f9
Since Rector configuration is used as a centralized config for all our Laravel based projects, we need to ensure that point to the root project and not to foundation itself.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
