### PR TITLE
refactor: document use default header sizes

### DIFF
--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -53,26 +53,20 @@ code.hljs .hljs-ln-n {
 }
 
 .documentation-content h1 {
-    @apply mb-8 text-2xl font-bold text-theme-secondary-900;
+    @apply mb-8;
 }
 
 .documentation-content h2 {
-    @apply pt-6 mt-6 mb-4 text-xl font-bold border-t text-theme-secondary-900 border-theme-secondary-200;
+    @apply pt-6 mt-6 mb-4 border-t border-theme-secondary-200;
 }
 .documentation-content h3 {
-    @apply mb-4 text-lg font-bold text-theme-secondary-900;
+    @apply mb-4;
 }
 
 /* Header Responsiveness */
 @screen sm {
     .documentation-content h2 {
-        @apply pt-10 mt-10 text-2xl;
-    }
-}
-
-@screen md {
-    .documentation-content h1 {
-        @apply text-4xl;
+        @apply pt-10 mt-10;
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/pf94dc

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
