### PR TITLE
refactor: use primary color for documentation header links

### DIFF
--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -288,7 +288,7 @@ aside .heading-permalink {
 .documentation-content h3 .heading-permalink,
 .documentation-content h4 .heading-permalink,
 main .documentation-content .heading-permalink {
-    @apply mr-3 text-theme-info-600 transition-default;
+    @apply mr-3 text-theme-primary-600 transition-default;
 }
 
 .documentation-content h2 .heading-permalink:hover,

--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -295,7 +295,7 @@ main .documentation-content .heading-permalink {
 .documentation-content h3 .heading-permalink:hover,
 .documentation-content h4 .heading-permalink:hover,
 main .documentation-content .heading-permalink:hover {
-    @apply no-underline text-theme-danger-400;
+    @apply no-underline text-theme-primary-400;
 }
 
 /* Gallery Grid */

--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -295,7 +295,7 @@ main .documentation-content .heading-permalink {
 .documentation-content h3 .heading-permalink:hover,
 .documentation-content h4 .heading-permalink:hover,
 main .documentation-content .heading-permalink:hover {
-    @apply no-underline text-theme-primary-400;
+    @apply no-underline text-theme-primary-700;
 }
 
 /* Gallery Grid */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1kvru0z

Note: also updates permalink hover colour for all projects

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
