### PR TITLE
refactor: move enable/disable scroll lock to reusable methods

### DIFF
--- a/resources/assets/js/modal.js
+++ b/resources/assets/js/modal.js
@@ -17,7 +17,7 @@ const Modal = {
         disableFocusTrap: false,
     },
 
-    onModalOpened(scrollable, settings = {}) {
+    disableBodyScroll(scrollable, settings = {}) {
         settings = Object.assign({}, this.defaultSettings, settings);
 
         if (settings.reserveScrollBarGap) {
@@ -31,15 +31,9 @@ const Modal = {
         disableBodyScroll(scrollable, {
             reserveScrollBarGap: !!settings.reserveScrollBarGap,
         });
-
-        if (settings.disableFocusTrap) {
-            scrollable.focus();
-        } else {
-            this.trapFocus(scrollable);
-        }
     },
 
-    onModalClosed(scrollable, settings = {}) {
+    enableBodyScroll(scrollable, settings = {}) {
         settings = Object.assign({}, this.defaultSettings, settings);
 
         if (settings.reserveScrollBarGap) {
@@ -51,6 +45,20 @@ const Modal = {
         }
 
         enableBodyScroll(scrollable);
+    },
+
+    onModalOpened(scrollable, settings = {}) {
+        this.disableBodyScroll(scrollable, settings);
+
+        if (settings.disableFocusTrap) {
+            scrollable.focus();
+        } else {
+            this.trapFocus(scrollable);
+        }
+    },
+
+    onModalClosed(scrollable, settings = {}) {
+        this.enableBodyScroll(scrollable, settings);
 
         this.releaseTrappedFocus();
 


### PR DESCRIPTION
…thod

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/1m7byu8

For the bug on msq I need to run the task for enabling and disable the scroll lock without focusing the scrollable content so this PR moves that logic to standalone methods that I can call without the need to call the focus methods.

The logic is the same only refactor the code

See msq PR for details

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
