### PR TITLE
chore: use `dev-master` for `larastan`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "livewire/livewire": "^2.6",
         "mockery/mockery": "^1.4",
         "nunomaduro/collision": "^5.10",
-        "nunomaduro/larastan": "^0.7",
+        "nunomaduro/larastan": "dev-master",
         "nunomaduro/laravel-mojito": "^0.2",
         "orchestra/testbench": "^6.21",
         "pestphp/pest": "^1.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0a2e3ee991aa0f9ce9667efa2112c2e",
+    "content-hash": "411b0842dfbb450b7cc056224929b8d6",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4374,16 +4374,16 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "v0.7.12",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "b2da312efe88d501aeeb867ba857e8c4198d43c0"
+                "reference": "92e474ddb6b4805e307570120701232cc7a9ce00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/b2da312efe88d501aeeb867ba857e8c4198d43c0",
-                "reference": "b2da312efe88d501aeeb867ba857e8c4198d43c0",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/92e474ddb6b4805e307570120701232cc7a9ce00",
+                "reference": "92e474ddb6b4805e307570120701232cc7a9ce00",
                 "shasum": ""
             },
             "require": {
@@ -4402,16 +4402,18 @@
                 "symfony/process": "^4.3 || ^5.0 || ^6.0"
             },
             "require-dev": {
+                "nikic/php-parser": "4.12.0",
                 "orchestra/testbench": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "phpunit/phpunit": "^7.3 || ^8.2 || ^9.3"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
             },
+            "default-branch": true,
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.6-dev"
+                    "dev-master": "0.7-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -4447,7 +4449,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/v0.7.12"
+                "source": "https://github.com/nunomaduro/larastan/tree/master"
             },
             "funding": [
                 {
@@ -4467,7 +4469,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-07-26T12:12:39+00:00"
+            "time": "2021-10-13T13:13:26+00:00"
         },
         {
             "name": "nunomaduro/laravel-mojito",
@@ -13400,7 +13402,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "nunomaduro/larastan": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
This https://github.com/nunomaduro/larastan/commit/88422fb90e85385245fb1badcaf5fbd8e0a1530d hasn't been released but we need it to properly fix some errors.