### PR TITLE
refactor: update registration form padding

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -16,7 +16,7 @@
 @section('content')
     <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading" />
 
-    <div class="py-8 mx-auto sm:max-w-xl">
+    <div class="mx-auto sm:max-w-xl">
         <livewire:auth.register-form />
 
         <div class="text-center">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -16,13 +16,11 @@
 @section('content')
     <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading" />
 
-    <div class="mx-auto sm:max-w-xl">
-        <livewire:auth.register-form />
+    <livewire:auth.register-form />
 
-        <div class="text-center">
-            <div class="mt-8">
-                @lang('ui::auth.register-form.already_member', ['route' => route('login')])
-            </div>
+    <div class="text-center">
+        <div class="mb-8">
+            @lang('ui::auth.register-form.already_member', ['route' => route('login')])
         </div>
     </div>
 @endsection


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The `register-form.blade.php` template uses the fortify `form-wrapper` component. This component includes y padding, which is basically doubling up the spacing above and below the registration form.

**Note: needs checking on other projects as they may not rely on the form-wrapper component like the fortify default component(s) use**

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
