### PR TITLE
fix: reset password validation on typing

### DIFF
--- a/src/Fortify/Components/UpdatePasswordForm.php
+++ b/src/Fortify/Components/UpdatePasswordForm.php
@@ -50,6 +50,11 @@ class UpdatePasswordForm extends Component
         $this->emit('toastMessage', [trans('ui::pages.user-settings.password_updated'), 'success']);
     }
 
+    public function updated(string $property): void
+    {
+        $this->clearValidation($property);
+    }
+
     /**
      * Render the component.
      *

--- a/tests/Fortify/Components/UpdatePasswordFormTest.php
+++ b/tests/Fortify/Components/UpdatePasswordFormTest.php
@@ -180,6 +180,5 @@ it('resets password validation on typing', function () {
         ->set('password_confirmation', 'password')
         ->assertHasErrors('password')
         ->set('password', 'password12!A%.-')
-        ->assertHasNoErrors('password')
-        ;
+        ->assertHasNoErrors('password');
 });

--- a/tests/Fortify/Components/UpdatePasswordFormTest.php
+++ b/tests/Fortify/Components/UpdatePasswordFormTest.php
@@ -165,3 +165,21 @@ it('clears password values', function () {
         ->assertSet('password', '')
         ->assertSet('password_confirmation', '');
 });
+
+it('resets password validation on typing', function () {
+    $user = createUserModel();
+
+    Livewire::actingAs($user)
+        ->test(UpdatePasswordForm::class)
+        ->assertSet('currentPassword', '')
+        ->assertSet('password', '')
+        ->assertSet('password_confirmation', '')
+        ->assertViewIs('ark-fortify::profile.update-password-form')
+        ->set('currentPassword', 'password')
+        ->set('password', 'password')
+        ->set('password_confirmation', 'password')
+        ->assertHasErrors('password')
+        ->set('password', 'password12!A%.-')
+        ->assertHasNoErrors('password')
+        ;
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1h29ba7

### To test

on msq go to `/account/settings/password` and try to update your password as described on the ticket, once the password is correct it should remove the validation error

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
