### PR TITLE
refactor: allow custom message for account deletion modal

### DIFF
--- a/resources/views/profile/delete-user-form.blade.php
+++ b/resources/views/profile/delete-user-form.blade.php
@@ -26,7 +26,11 @@
                         <x-ark-icon name="fortify-modal.delete-account" class="w-2/3 h-auto text-theme-primary-600"/>
                     </div>
                     <div class="mt-4">
-                        @lang('forms.delete-user.confirmation')
+                        @if(trans()->has('forms.delete-user.confirmation'))
+                            @lang('forms.delete-user.confirmation')
+                        @else
+                            @lang('ui::forms.delete-user.confirmation', ['appName' => config('app.name')])
+                        @endunless
                     </div>
                 </div>
                 <form class="mt-8">


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1j4h0av

Was previously using something hardcoded that we could not change on our others apps. Alternatively, could probably keep using the `@lang('ui::')` one but maybe using `APP_NAME` within it so it's always based on our different possible names.

Edit: Ok maybe not for the solution above, since some texts doesn't mention the app name at all.

## Checklist

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged