### PR TITLE
Revert "refactor: allow custom message for account deletion modal"

### DIFF
--- a/resources/views/profile/delete-user-form.blade.php
+++ b/resources/views/profile/delete-user-form.blade.php
@@ -26,11 +26,7 @@
                         <x-ark-icon name="fortify-modal.delete-account" class="w-2/3 h-auto text-theme-primary-600"/>
                     </div>
                     <div class="mt-4">
-                        @if(trans()->has('forms.delete-user.confirmation'))
-                            @lang('forms.delete-user.confirmation')
-                        @else
-                            @lang('ui::forms.delete-user.confirmation', ['appName' => config('app.name')])
-                        @endunless
+                        @lang('ui::forms.delete-user.confirmation')
                     </div>
                 </div>
                 <form class="mt-8">


### PR DESCRIPTION
Reverts ArkEcosystem/laravel-foundation#74

can be overwritten in the project, and current changes don't do anything with the `appName` anyway