### PR TITLE
feat: add UrlInStringWrapper string macro

### DIFF
--- a/src/Providers/FoundationServiceProvider.php
+++ b/src/Providers/FoundationServiceProvider.php
@@ -27,5 +27,6 @@ class FoundationServiceProvider extends ServiceProvider
         $this->app->register(FortifyServiceProvider::class);
         $this->app->register(RulesServiceProvider::class);
         $this->app->register(UserInterfaceServiceProvider::class);
+        $this->app->register(StringMacroServiceProvider::class);
     }
 }

--- a/src/Providers/StringMacroServiceProvider.php
+++ b/src/Providers/StringMacroServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\Providers;
+
+use ARKEcosystem\Foundation\Support\UrlInStringWrapper;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+
+class StringMacroServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+
+    public function boot(): void
+    {
+        Str::macro('wrapUrlsInBlankATag', function ($str, $attributes = []): string {
+            $wrapper = new UrlInStringWrapper($str);
+            $wrapper->setAttributes($attributes);
+
+            return $wrapper->getString();
+        });
+    }
+}

--- a/src/Support/UrlInStringWrapper.php
+++ b/src/Support/UrlInStringWrapper.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\Support;
+
+use Illuminate\Support\Str;
+
+/*
+ * Some email clients will parse the content for urls, so they can convert them to a tags for convenience.
+ * Since some emails contain user entered data we have no control over these links, we don't like this because of
+ * security issues. With this Class we can check if parts of the string matches an url notation (with or without
+ * http(s)).
+ *
+ * Since adding an a tag will change the styling, you can optionally add one or more attributes to adapt the styling
+ * as an array where the index is the attribute and de value the value of the attribute.
+ *
+ * This class is available through a Str macro: \Str::wrapUrlsInBlankATag($string, $attributes);
+ */
+final class UrlInStringWrapper
+{
+    private array $attributes = [];
+
+    public function __construct(protected string $value)
+    {
+    }
+
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function getString(): string
+    {
+        $pattern = '/[a-zA-Z0-9]*[\.\-\:].\S*/';
+
+        preg_match_all($pattern, $this->value, $matches);
+
+        if (count($matches[0]) === 0) {
+            return $this->value;
+        }
+
+        foreach ($matches[0] as $index => $match) {
+            $this->value = Str::replace(
+                $match,
+                '<a'.$this->attributesString().'>'.$match.'</a>',
+                $this->value
+            );
+        }
+
+        return $this->value;
+    }
+
+    private function attributesString(): string
+    {
+        if (count($this->attributes) === 0) {
+            return '';
+        }
+
+        return ' '.collect($this->attributes)->map(function ($value, $attr) {
+            return $attr.'="'.$value.'"';
+        })->implode(' ');
+    }
+}

--- a/tests/Support/UrlInStringWrapperTest.php
+++ b/tests/Support/UrlInStringWrapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use ARKEcosystem\Foundation\Support\UrlInStringWrapper;
+
+it('will not change the value when no url is detected', function () {
+    $value = 'This is a normal string.';
+    $newValue = (new UrlInStringWrapper($value))->getString();
+
+    expect($newValue)->toBe($value);
+});
+
+it('will wrap the url in a blank a tag when a url is detected', function () {
+    $value = 'Your invitation for test.com has been created.';
+    $newValue = (new UrlInStringWrapper($value))->getString();
+
+    expect($newValue)->toBe('Your invitation for <a>test.com</a> has been created.');
+});
+
+it('will wrap two urls in a blank a tag when a url is detected', function ($value, $expectation) {
+    $newValue = (new UrlInStringWrapper("Your invitation for {$value} has been created."))->getString();
+
+    expect($newValue)->toBe("Your invitation for {$expectation} has been created.");
+})->with([
+    ['foo.com', '<a>foo.com</a>'],
+    ['https://foo.com', '<a>https://foo.com</a>'],
+    ['test.com and test2.com', '<a>test.com</a> and <a>test2.com</a>'],
+    ['foo123bar.com', '<a>foo123bar.com</a>'],
+    ['foo.bar.com', '<a>foo.bar.com</a>'],
+    ['foo-bar.foobar.com', '<a>foo-bar.foobar.com</a>'],
+    ['foobar.com/test', '<a>foobar.com/test</a>'],
+    ['foobar.com/test/', '<a>foobar.com/test/</a>'],
+    ['foobar.com/test?foo=bar&bar=foo', '<a>foobar.com/test?foo=bar&bar=foo</a>'],
+    ['foobar.com/foo@barbar[foo=bar]', '<a>foobar.com/foo@barbar[foo=bar]</a>'],
+]);
+
+it('will add optional attributes', function () {
+    $value = 'Your invitation for test.com has been created.';
+
+    $wrapper = new UrlInStringWrapper($value);
+    $wrapper->setAttributes(['class' => 'text-black', 'style' => 'color: #000000']);
+
+    expect($wrapper->getString())
+        ->toBe('Your invitation for <a class="text-black" style="color: #000000">test.com</a> has been created.');
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1pqfm7t

```
/*
 * Some email clients will parse the content for urls, so they can convert them to a tags for convenience.
 * Since some emails contain user entered data we have no control over these links, we don't like this because of
 * security issues. With this Class we can check if parts of the string matches an url notation (with or without
 * http(s)).
 *
 * Since adding an a tag will change the styling, you can optionally add one or more attributes to adapt the styling
 * as an array where the index is the attribute and de value the value of the attribute.
 *
 * This class is available through a Str macro: \Str::wrapUrlsInBlankATag($string, $attributes);
 */
```

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
* I've placed the `UrlInStringWrapper` class in a new `Support` folder under `scr`. Please let me know if this is not the desired structure.
* I've created a new `StringMacroServiceProvider` to Foundation since the other Service Providers are also very specific. Let me know if this should be changed to something more generic like `ViewServiceProvider`.
