### PR TITLE
refactor: ignore phpstan error "Constructor in ... has parameter ... with default value"

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,5 @@ parameters:
     level: 8
     ignoreErrors:
         - '#is not allowed to extend#'
+        - '#Constructor in ([\w\\]+) has parameter ([\$\w]+) with default value.#'
     checkMissingIterableValueType: false

--- a/src/Fortify/Components/Concerns/InteractsWithUser.php
+++ b/src/Fortify/Components/Concerns/InteractsWithUser.php
@@ -7,6 +7,9 @@ namespace ARKEcosystem\Foundation\Fortify\Components\Concerns;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
 
+/**
+ * @property ?Authenticatable $user
+ */
 trait InteractsWithUser
 {
     public function getUserProperty(): ?Authenticatable


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1rgqjxw

This PR ignores the phpstan error "Constructor in ... has parameter ... with default value."
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
