### PR TITLE
refactor: phpcs-fixer issues with @var declarations

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -127,7 +127,7 @@ $rules = [
     'phpdoc_scalar'                         => true,
     'phpdoc_single_line_var_spacing'        => true,
     'phpdoc_summary'                        => true,
-    'phpdoc_to_comment'                     => true,
+    'phpdoc_to_comment'                     => ['ignored_tags' => ['var']],
     'phpdoc_trim'                           => true,
     'phpdoc_types'                          => true,
     'phpdoc_var_without_name'               => true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The `phpdoc_to_comment` rule on the `.php-cs-fixer.php`  file is removing an `*` from some @var declarations which cause an error with phpstan where that declaration is used

You can see the problem in this commit: https://github.com/ArkEcosystem/marketsquare.io/pull/2387/commits/190d7394f1d76e1ffab07fd9c8c3227d3d05d223

After `php-cs-fixer` refactor the code phpstan complains about the issue that was meant to be solved

More info about the `phpdoc_to_comment ` rule here https://cs.symfony.com/doc/rules/phpdoc/phpdoc_to_comment.html

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
