### PR TITLE
fix: remove scroll lock when closing crop modal

### DIFF
--- a/resources/assets/js/crop-image.js
+++ b/resources/assets/js/crop-image.js
@@ -41,6 +41,8 @@ const CropImage = (
         this.uploadEl = document.getElementById($uploadID);
 
         Livewire.on("discardCroppedImage", () => {
+            Livewire.emit("closeModal", $modalID);
+
             this.discardImage();
         });
 
@@ -48,6 +50,7 @@ const CropImage = (
             Livewire.emit("closeModal", $modalID);
 
             this.saveCroppedImage();
+            this.discardImage();
         });
     },
 
@@ -137,8 +140,6 @@ const CropImage = (
                 this.model = response.url;
             });
         });
-
-        this.discardImage();
     },
 
     discardImage() {

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -158,11 +158,6 @@
         name="crop-modal-{{ $id }}"
         class="w-full max-w-2xl text-left"
         title-class="header-2"
-        x-data="{
-            onHidden: () => {
-                Livewire.emit('discardCroppedImage');
-            },
-        }"
         close-button-only
         init
     >
@@ -183,7 +178,7 @@
         @endslot
 
         @slot('buttons')
-            <button type="button" class="{{ $cropCancelButtonClass }}" @click="hide" dusk="crop-cancel-button">
+            <button type="button" class="{{ $cropCancelButtonClass }}" @click="Livewire.emit('discardCroppedImage')" dusk="crop-cancel-button">
                 {{ $cropCancelButton }}
             </button>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1u9wyqy

This PR fixes an issue with crop image modal not removing the scroll lock when discarded.

## How to test
1. merge this on MSQ
1. add new project
1. add platform/category and go to page 2
1. click on the image upload component
1. click `back` on the opened modal
1. expect to be able to scroll the page as usual

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
