### PR TITLE
bug: alert styling and FlashTypes do not match

### DIFF
--- a/src/UserInterface/Support/Enums/FlashType.php
+++ b/src/UserInterface/Support/Enums/FlashType.php
@@ -6,15 +6,15 @@ namespace ARKEcosystem\Foundation\UserInterface\Support\Enums;
 
 final class FlashType
 {
-    public const INFO    = 'alert-info';
+    public const INFO    = 'info';
 
-    public const SUCCESS = 'alert-success';
+    public const SUCCESS = 'success';
 
-    public const WARNING = 'alert-warning';
+    public const WARNING = 'warning';
 
-    public const DANGER  = 'alert-danger';
+    public const DANGER  = 'danger';
 
-    public const ERROR   = 'alert-error';
+    public const ERROR   = 'error';
 
-    public const HINT    = 'alert-hint';
+    public const HINT    = 'hint';
 }


### PR DESCRIPTION
## Summary
https://app.clickup.com/t/1mf3z8f

The FlashTypes are used to set the right type on the <x-ark-alert /> component.
The Enum delivers strings prefixed with `alert-`, but the <x-ark-alert /> component doesn't need this.

I've checked the usage in MSQ and this change should not cause compatibility with the current usage and will solve the bug.


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
