### PR TITLE
fix: remove image collection delete button while loading

### DIFF
--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -93,15 +93,17 @@
                                 @endif
                             </div>
 
-                            <button
-                                type="button"
-                                data-action
-                                class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
-                                wire:click="deleteImage({{ $index }})"
-                                data-tippy-hover="{{ $deleteTooltip }}"
-                            >
-                                <x-ark-icon name="close" size="sm"/>
-                            </button>
+                            <div wire:loading.remove="updateImageOrder">
+                                <button
+                                    type="button"
+                                    data-action
+                                    class="absolute top-0 right-0 p-1 -mt-2 -mr-2 rounded cursor-pointer bg-theme-danger-100 text-theme-danger-500"
+                                    wire:click="deleteImage({{ $index }})"
+                                    data-tippy-hover="{{ $deleteTooltip }}"
+                                >
+                                    <x-ark-icon name="close" size="sm"/>
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
https://app.clickup.com/t/1mf0q5e

When the delete button is clicked while the image order is not yet completed after reordering, the deletion will result in deleting the wrong image or a `Trying to access array offset on value of type null` exception.

The simplest fix is to remove the delete button while the sorting is not yet finished. This will hardly or not at all be a visual change for the user since this will be just a fraction of a second and also only visible while hovering over an image.

I couldn't put the `wire:loading.remove="updateImageOrder"` on the button because of a known Livewire issue (https://github.com/livewire/livewire/issues/1012#issuecomment-687573922) with `wire:click` and `wire:loading` on the same element. I had to wrap the button in a `div` to make it work.

## How to test
I wasn't able to reproduce the exception as provided in the Clickup card since the timing is really tight and my Mac might be too fast :trollface: 
After inserting `sleep(1);` in `UploadImageCollection` in the `updateImageOrder()` method I could get the exception:
https://github.com/ArkEcosystem/laravel-foundation/blob/8a0eed29446a19d6f5724e155c1b83facc2854b3/src/UserInterface/Components/UploadImageCollection.php#L98-L100

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
