### PR TITLE
refactor: remove `header-2` title class from "js-modal" component

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -3,7 +3,6 @@
 <x-ark-js-modal
     name="external-link-confirm"
     class="w-full max-w-2xl text-left rounded-xl"
-    title-class="header-2"
     buttons-style="flex justify-end space-x-3"
     x-data="{
         url: null,

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -157,7 +157,6 @@
     <x-ark-js-modal
         name="crop-modal-{{ $id }}"
         class="w-full max-w-2xl text-left"
-        title-class="header-2"
         close-button-only
         init
     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1vx9hte

Since "js-modal" component now uses H2 for title, we don't need to implicitly add the header-2 class to style it.

## How to test
- see https://github.com/ArkEcosystem/marketsquare.io/pull/2482#issue-792791200

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
