### PR TITLE
fix: change title padding-bottom on "js-modal"

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -32,7 +32,7 @@
     @endslot
 
     @slot('description')
-        <div class="flex flex-col mt-8 space-y-4 whitespace-normal">
+        <div class="flex flex-col mt-6 space-y-4 whitespace-normal">
             <div class="font-semibold text-theme-secondary-900">
                 <div class="alert-wrapper alert-warning">
                     <div class="alert-icon-wrapper alert-warning-icon flex-no-wrap">

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -171,7 +171,7 @@
                 </div>
             @endif
 
-            <div class="-mx-8 mt-8 sm:-mx-10 sm:mt-10 h-75">
+            <div class="-mx-8 mt-6 sm:-mx-10 sm:mt-10 h-75">
                 <img id="image-single-crop-{{ $id }}" src="" alt="">
             </div>
         @endslot

--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -4,7 +4,7 @@
     'class' => '',
     'widthClass' => 'max-w-2xl',
     'title' => null,
-    'titleClass' => 'inline-block pb-2 font-bold dark:text-theme-secondary-200',
+    'titleClass' => 'inline-block pb-4 font-bold dark:text-theme-secondary-200',
     'buttons' => null,
     'buttonsStyle' => 'modal-buttons',
     'closeButtonOnly' => false,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1vxangv

This PR fixes the margin between js-modal title and description to 16px.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
