### PR TITLE
fix: vertical space on "js-modal" component

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -32,7 +32,7 @@
     @endslot
 
     @slot('description')
-        <div class="flex flex-col mt-6 space-y-4 whitespace-normal">
+        <div class="flex flex-col mt-4 space-y-6 whitespace-normal">
             <div class="font-semibold text-theme-secondary-900">
                 <div class="alert-wrapper alert-warning">
                     <div class="alert-icon-wrapper alert-warning-icon flex-no-wrap">

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -55,6 +55,7 @@
             <x-ark-checkbox
                 name="confirmation"
                 alpine="toggle"
+                label-classes="text-theme-secondary-700 select-none"
             >
                 @slot('label')
                     @lang('ui::forms.do_not_show_message_again')

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -169,7 +169,7 @@
                 <p>{!! $cropMessage !!}</p>
             @endif
 
-            <div class="mt-8 -mx-8 sm:-mx-10 h-75">
+            <div class="-mx-8 mt-8 sm:-mx-10 h-75">
                 <img id="image-single-crop-{{ $id }}" src="" alt="">
             </div>
         @endslot

--- a/resources/views/inputs/upload-image-single.blade.php
+++ b/resources/views/inputs/upload-image-single.blade.php
@@ -166,12 +166,10 @@
 
         @slot('description')
             @if($cropMessage)
-                <div class="mt-3">
-                    {!! $cropMessage !!}
-                </div>
+                <p>{!! $cropMessage !!}</p>
             @endif
 
-            <div class="-mx-8 mt-6 sm:-mx-10 sm:mt-10 h-75">
+            <div class="mt-8 -mx-8 sm:-mx-10 h-75">
                 <img id="image-single-crop-{{ $id }}" src="" alt="">
             </div>
         @endslot

--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -4,7 +4,7 @@
     'class' => '',
     'widthClass' => 'max-w-2xl',
     'title' => null,
-    'titleClass' => 'inline-block pb-4 font-bold dark:text-theme-secondary-200',
+    'titleClass' => 'inline-block pb-3 font-bold dark:text-theme-secondary-200',
     'buttons' => null,
     'buttonsStyle' => 'modal-buttons',
     'closeButtonOnly' => false,


### PR DESCRIPTION

## Summary
https://app.clickup.com/t/1w8man9

Fixes the vertical space (margin/padding) between title, description, image.. on js-modal and component that using js-modal, like external-link, crop image.

## How to test
1. merge it on Marketsquare
1. open project and click on "website"
1. expects to see "external link" modal (https://www.figma.com/file/6VhdbE82NloQmxd6kJiGGN/MSQ?node-id=345%3A124979)
1. register new project, go to page 2
1. upload an image
1. expects to see "crop image" modal (https://www.figma.com/file/6VhdbE82NloQmxd6kJiGGN/MSQ?node-id=631%3A173889)

---

1. merge it on Payvo
1. open "view profile"
1. click on "qr-code" icon
1. expects to see "qr-code" modal (https://www.figma.com/file/89WPrtXdAWOvvmrpr2uypY/Payvo.com?node-id=271%3A16586)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
