### PR TITLE
fix: notification filter dropdown using wrong lang file

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -32,7 +32,7 @@
                         <div class="py-3">
                             @foreach ($this->getAvailableFilters() as $filter)
                                 <button type="button" class="cursor-pointer focus-visible:ring-inset dropdown-entry" wire:click="$set('activeFilter', '{{ $filter }}')">
-                                    @lang("hermes::menus.notifications-dropdown.{$filter}")
+                                    @lang("ui::menus.notifications-dropdown.{$filter}")
                                 </button>
                             @endforeach
                         </div>


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1n5x71q

Currently the notification dropdown for filtering all, read, unread etc. is trying to read from a non-existent lang file. This change fixes that by reading from ui:menus.notifications-dropdown...

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
