### PR TITLE
fix: create override to force use `action.url` in DatabaseNotification

### DIFF
--- a/src/Hermes/Models/DatabaseNotification.php
+++ b/src/Hermes/Models/DatabaseNotification.php
@@ -58,6 +58,10 @@ abstract class DatabaseNotification extends BaseNotification
 
     public function link(): ?string
     {
+        if (data_get($this->data, 'action.use_action_url', false)) {
+            return data_get($this->data, 'action.url');
+        }
+
         /* @phpstan-ignore-next-line  */
         return data_get($this->relatable, 'link')
             ?? data_get($this->data, 'action.url');

--- a/src/Hermes/Models/DatabaseNotification.php
+++ b/src/Hermes/Models/DatabaseNotification.php
@@ -58,7 +58,7 @@ abstract class DatabaseNotification extends BaseNotification
 
     public function link(): ?string
     {
-        if (data_get($this->data, 'action.use_action_url', false)) {
+        if (data_get($this->data, 'action.force', false)) {
             return data_get($this->data, 'action.url');
         }
 


### PR DESCRIPTION
## Summary
https://app.clickup.com/t/1x58xef

The bug is described in the Clickup Card. 
I couldn't find an easy way to write a test for it since there are no other Models present in foundation to make this work.
Since there are no existing tests for the `DatabaseNotification` in the test suite, I figured that is ok.

If needed, I can also create some test Models to be only used in the test suite to make it all testable. Let me know!

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
