### PR TITLE
feat: add dark styles to tags

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -256,7 +256,7 @@ input[type="password"]::-ms-reveal {
 }
 
 .taggle_list .taggle .close {
-    @apply items-center p-1 text-lg leading-3 no-underline rounded cursor-pointer pointer-events-none right-2 text-theme-secondary-900 bg-theme-primary-200 whitespace-nowrap;
+    @apply items-center p-1 text-lg leading-3 no-underline rounded cursor-pointer pointer-events-none right-2 text-theme-secondary-900 bg-theme-primary-200 whitespace-nowrap dark:bg-theme-secondary-700;
 }
 
 .taggle_list .taggle:hover {
@@ -268,15 +268,15 @@ input[type="password"]::-ms-reveal {
 }
 
 .taggle_list .taggle .close:hover {
-    @apply text-theme-primary-600;
+    @apply text-theme-primary-600 dark:text-theme-secondary-200;
 }
 
 .taggle_placeholder {
-    @apply absolute top-0 left-0 max-w-full p-3 truncate rounded pointer-events-none text-theme-secondary-400;
+    @apply absolute top-0 left-0 max-w-full p-3 truncate rounded pointer-events-none text-theme-secondary-400 dark:text-theme-secondary-700;
 }
 
 .taggle_input {
-    @apply max-w-full my-1 bg-none;
+    @apply max-w-full my-1 bg-transparent;
 }
 
 .taggle_sizer {
@@ -286,11 +286,11 @@ input[type="password"]::-ms-reveal {
 }
 
 .taggle_text {
-    @apply truncate text-theme-primary-600;
+    @apply truncate text-theme-primary-600 dark:text-theme-secondary-200;
 }
 
 .taggle {
-    @apply space-x-2 bg-theme-primary-100;
+    @apply space-x-2 bg-theme-primary-100 dark:bg-theme-secondary-800;
 }
 
 .disabled-tags-input .tags-input-focus {

--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -250,7 +250,7 @@ input[type="password"]::-ms-reveal {
 }
 
 .taggle_list .taggle {
-    @apply flex items-center pl-2 pr-1 space-x-2 overflow-auto rounded bg-theme-primary-100;
+    @apply flex items-center pl-2 pr-1 space-x-2 overflow-auto rounded bg-theme-primary-100 dark:bg-theme-secondary-800;;
     padding-top: 0.25rem !important;
     padding-bottom: 0.25rem !important;
 }

--- a/resources/views/inputs/tags.blade.php
+++ b/resources/views/inputs/tags.blade.php
@@ -41,7 +41,7 @@
             <div
                 wire:ignore
                 x-ref="input"
-                class="relative py-2 px-3 bg-white rounded border border-theme-secondary-400"
+                class="relative py-2 px-3 bg-white rounded border border-theme-secondary-400 dark:bg-theme-secondary-900 dark:border-theme-secondary-700"
             >
             </div>
 


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1wu12an

This PR adds dark mode support to the `taggle` class which is used on marketsquare project registration for adding tags to a project.

Corresponding MSQ PR for testing [here](https://github.com/ArkEcosystem/marketsquare.io/pull/2534).

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
