### PR TITLE
refactor: adjust vertical form spacing

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -16,37 +16,33 @@
 @section('content')
     <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading"/>
 
-    <div class="py-8 mx-auto max-w-xl">
-        <div class="px-8">
-            <x-ark-flash/>
-        </div>
+    <div class="py-8 space-y-8 mx-auto max-w-xl">
+        <x-ark-flash />
 
-        <div class="mt-5 lg:mt-8">
-            <x:ark-fortify::form-wrapper :action="route('password.email')">
-                <div class="mb-8">
-                    <div class="flex flex-1">
-                        <x-ark-input
-                            type="email"
-                            name="email"
-                            label="Email"
-                            autocomplete="email"
-                            class="w-full"
-                            :autofocus="true"
-                            :required="true"
-                        />
-                    </div>
+        <x:ark-fortify::form-wrapper class="sm:max-w-xl" :action="route('password.email')">
+            <div class="mb-8">
+                <div class="flex flex-1">
+                    <x-ark-input
+                        type="email"
+                        name="email"
+                        label="Email"
+                        autocomplete="email"
+                        class="w-full"
+                        :autofocus="true"
+                        :required="true"
+                    />
+                </div>
+            </div>
+
+            <div class="flex flex-col-reverse justify-between items-center space-y-4 md:flex-row md:space-y-0">
+                <div class="flex-1 mt-8 md:mt-0">
+                    <a href="{{ route('login') }}" class="link">@lang('ui::actions.cancel')</a>
                 </div>
 
-                <div class="flex flex-col-reverse justify-between items-center space-y-4 md:flex-row md:space-y-0">
-                    <div class="flex-1 mt-8 md:mt-0">
-                        <a href="{{ route('login') }}" class="link">@lang('ui::actions.cancel')</a>
-                    </div>
-
-                    <button type="submit" class="w-full md:w-auto button-secondary">
-                        @lang('ui::auth.forgot-password.reset_link')
-                    </button>
-                </div>
-            </x:ark-fortify::form-wrapper>
-        </div>
+                <button type="submit" class="w-full md:w-auto button-secondary">
+                    @lang('ui::auth.forgot-password.reset_link')
+                </button>
+            </div>
+        </x:ark-fortify::form-wrapper>
     </div>
 @endsection

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -16,7 +16,7 @@
 @section('content')
     <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading"/>
 
-    <div class="py-8 space-y-8 mx-auto max-w-xl">
+    <div class="py-8 mx-auto space-y-8 max-w-xl">
         <x-ark-flash />
 
         <x:ark-fortify::form-wrapper class="sm:max-w-xl" :action="route('password.email')">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -16,7 +16,5 @@
 @section('content')
     <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading" />
 
-    <div class="py-8 mx-auto max-w-xl">
-        <livewire:auth.reset-password-form :token="request()->route('token')" :email="old('email', request()->email)" />
-    </div>
+    <livewire:auth.reset-password-form :token="request()->route('token')" :email="old('email', request()->email)" />
 @endsection

--- a/resources/views/components/form-wrapper.blade.php
+++ b/resources/views/components/form-wrapper.blade.php
@@ -1,6 +1,10 @@
-@props(['action', 'method' => 'POST'])
+@props([
+    'action',
+    'method' => 'POST',
+    'class'  => 'py-8 mx-auto sm:max-w-xl'
+])
 
-<div class="py-8 mx-auto sm:max-w-xl" {{ $attributes }}>
+<div {{ $attributes->merge(['class' => $class]) }}>
     <form action="{{ $action }}" method="{{ $method }}" class="flex flex-col px-8 pb-8 border-b-2 sm:pt-8 sm:rounded-xl sm:border-2 border-theme-secondary-200 dark:border-theme-secondary-800">
         @csrf
         {{ $slot  }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1n00ev8

This PR adjusts vertical form spacing on `forgot-password` and `reset-password` forms.
This change will be automatically applied on all projects that using this library.

## How to test
- merge it on MSQ
- run `composer db:dev`
- open `/forgot-password`
- expects to see the correct vertical spacing (32px) https://www.figma.com/file/6VhdbE82NloQmxd6kJiGGN/MSQ?node-id=125%3A36792
- insert an email address `xxx@ark.io` and click "send reset link"
- open telescope `/telescope/mail`
- open the `SendPasswordResetNotification`
- click on the "reset password" inside the email
- expects to see the correct vertical spacing (32px)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [x] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
