### PR TITLE
refactor: dark mode for blog article (markdown styling)

### DIFF
--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -181,7 +181,7 @@ code.hljs .hljs-ln-n {
 .documentation-content iframe,
 .documentation-content .typeform-widget,
 .documentation-content .image-container .twitter-tweet {
-    @apply border rounded-xl border-theme-secondary-300 overflow-hidden dark:border-theme-secondary-800 ;
+    @apply border rounded-xl border-theme-secondary-300 overflow-hidden dark:border-theme-secondary-800;
 }
 
 .documentation-content .image-container .twitter-tweet {

--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -161,7 +161,7 @@ code.hljs .hljs-ln-n {
 
 /* Divider */
 .documentation-content hr {
-    @apply my-6 border-theme-secondary-200 bg-theme-secondary-200;
+    @apply my-6 border-theme-secondary-200 bg-theme-secondary-200 dark:border-theme-secondary-800 dark:bg-theme-secondary-800;
 }
 
 /* Image */
@@ -181,7 +181,7 @@ code.hljs .hljs-ln-n {
 .documentation-content iframe,
 .documentation-content .typeform-widget,
 .documentation-content .image-container .twitter-tweet {
-    @apply border rounded-xl border-theme-secondary-300 overflow-hidden;
+    @apply border rounded-xl border-theme-secondary-300 overflow-hidden dark:border-theme-secondary-800 ;
 }
 
 .documentation-content .image-container .twitter-tweet {
@@ -198,7 +198,7 @@ code.hljs .hljs-ln-n {
 
 /* Image caption */
 .documentation-content .image-caption {
-    @apply relative block mx-auto text-theme-secondary-800 border-l-2 border-theme-secondary-300 text-sm px-3 mt-3 italic text-center;
+    @apply relative block mx-auto text-theme-secondary-800 dark:text-theme-secondary-200 border-l-2 border-theme-secondary-300 text-sm px-3 mt-3 italic text-center dark:border-theme-secondary-800;
 }
 
 /* Misc */
@@ -219,7 +219,7 @@ code.hljs .hljs-ln-n {
 }
 
 .documentation-content blockquote {
-    @apply block pl-4 border-l-2 text-theme-secondary-500 border-theme-secondary-300;
+    @apply block pl-4 border-l-2 text-theme-secondary-500 border-theme-secondary-300 dark:border-theme-secondary-700 dark:text-theme-secondary-700;
 }
 
 /* Table */
@@ -232,7 +232,7 @@ code.hljs .hljs-ln-n {
 }
 
 .documentation-content table thead tr {
-    @apply text-left border-b border-theme-secondary-300;
+    @apply text-left border-b border-theme-secondary-300  dark:border-theme-secondary-800;
 }
 
 .documentation-content table thead th {
@@ -242,7 +242,7 @@ code.hljs .hljs-ln-n {
 .documentation-content table thead th:not(:last-child)::after {
     content: "";
     height: 50%;
-    @apply absolute right-0 border-l border-theme-secondary-300;
+    @apply absolute right-0 border-l border-theme-secondary-300  dark:border-theme-secondary-800;
 }
 
 .documentation-content table tbody td {
@@ -250,7 +250,7 @@ code.hljs .hljs-ln-n {
 }
 
 .documentation-content table tbody tr {
-    @apply border-b border-dashed border-theme-secondary-300;
+    @apply border-b border-dashed border-theme-secondary-300  dark:border-theme-secondary-800;
 }
 
 .documentation-content table tbody tr:last-child {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1wu10ff

Updates the markdown styling for dark mode

![image](https://user-images.githubusercontent.com/17262776/145870951-dbfbafa1-e041-4088-8744-3c45b98c2c56.png)

**Notes**

1. Notice that [the design](https://www.figma.com/file/6VhdbE82NloQmxd6kJiGGN/MSQ?node-id=4175%3A279847) doesn't have all the elements on the markdown (like tables, hr separators, etc so I tried to follow the style we have generally
2. The image caption is different from the design but that is in purpose (asked Oleg)
3. I am not updating the image placeholder but created a ticket for that instead https://app.clickup.com/t/1truvpa

To test: try to create an article with all the markdown components you can think (headers, links, images, etc) of and ensure they looks good in dark mode

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
