### PR TITLE
refactor: register form dark mode inputs

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -36,7 +36,9 @@ input[type="password"]::-ms-reveal {
     padding: 0.75rem 3.25rem 0.75rem 0.75rem;
 }
 
-.dark .input-text::placeholder {
+.dark .input-text::placeholder,
+.dark .input-text-with-prefix::placeholder,
+.dark .input-text-with-suffix::placeholder {
     @apply text-theme-secondary-700;
 }
 

--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -121,15 +121,15 @@ input[type="password"]::-ms-reveal {
 
 .input-wrapper-with-prefix,
 .input-wrapper-with-suffix {
-    @apply flex bg-white border rounded border-theme-secondary-300 dark:border-theme-secondary-700 dark:bg-theme-secondary-800;
+    @apply flex bg-white border rounded border-theme-secondary-300 dark:border-theme-secondary-700 dark:bg-theme-secondary-900;
 }
 
 .input-wrapper-with-prefix .input-prefix-icon {
-    @apply text-theme-secondary-500;
+    @apply text-theme-secondary-500 dark:text-theme-secondary-700;
 }
 .input-wrapper-with-prefix--dirty .input-prefix-icon,
 .input-wrapper-with-prefix:focus-within .input-prefix-icon {
-    @apply text-theme-primary-500;
+    @apply text-theme-primary-500 dark:text-theme-primary-600;
 }
 .input-wrapper-with-prefix .input-prefix {
     @apply border-r dark:border-theme-secondary-700;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1wu12fh

Adjusts the form inputs with icons used on the registration form:

To test: merge on msq, recompile, compare design
![image](https://user-images.githubusercontent.com/17262776/145876666-24e8902f-ba32-436d-9ee7-9e3eeac0ece6.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
