### PR TITLE
refactor: password toggle use darker blue on dark mode

### DIFF
--- a/resources/views/inputs/password-toggle.blade.php
+++ b/resources/views/inputs/password-toggle.blade.php
@@ -48,7 +48,7 @@
             <button
                 type="button"
                 @class([
-                    'right-0 px-4 input-icon text-theme-primary-300 rounded',
+                    'right-0 px-4 input-icon text-theme-primary-300 dark:text-theme-primary-600 rounded',
                     'text-theme-danger-500' => $errors->has($name),
                 ])
                 @click="toggle()"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1xb4882

Didnt find a design for this but I assume is just using a darker blue:

![image](https://user-images.githubusercontent.com/17262776/145909328-54baaa58-fb51-45df-bfa5-1c543ecef2d9.png)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
