### PR TITLE
refactor: add navbar dropdown shadow

### DIFF
--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
                 20: "20px",
             },
             boxShadow: {
+                "navbar-dropdown": "0px 15px 35px 0 rgba(33, 34, 37, 0.08)",
                 "lg-smooth":
                     "0 10px 15px -3px rgba(0, 0, 0, 0.025), 0 4px 6px -2px rgba(0, 0, 0, 0.025)",
                 "header-smooth": " 0px 2px 10px 0px rgba(192, 200, 207, 0.22)",

--- a/resources/tailwind.config.js
+++ b/resources/tailwind.config.js
@@ -53,6 +53,7 @@ module.exports = {
             },
             inset: {
                 "13": "3.25rem",
+                "21": "5.25rem",
             },
         },
 

--- a/resources/views/navbar/items/desktop.blade.php
+++ b/resources/views/navbar/items/desktop.blade.php
@@ -64,7 +64,7 @@
                         x-ref="menuDropdown"
                         id="{{ $menuDropdownId }}"
                         x-show.transition.origin.top="openDropdown === '{{ $navItem['label'] }}'"
-                        class="absolute top-0 left-0 z-30 py-4 mt-24 bg-white rounded-xl"
+                        class="absolute top-0 left-0 z-30 py-4 mt-24 bg-white rounded-xl shadow-navbar-dropdown"
                         x-cloak
                     >
                         <div class="flex">

--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -26,7 +26,7 @@
     }"
     x-cloak
 >
-    <div class="overflow-y-auto max-h-full pointer-events-auto bg-white pt-2 pb-4 rounded-b-lg">
+    <div class="overflow-y-auto pt-2 pb-4 max-h-full bg-white rounded-b-lg pointer-events-auto">
         @if(isset($navbarNotificationsMobile) || isset($notifications))
             <div class="flex justify-center items-center py-0.5 px-2 my-4 mx-8 rounded border shadow-sm md:hidden border-theme-secondary-300">
                 @isset($navbarNotificationsMobile)

--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -15,8 +15,19 @@
     ][$breakpoint];
 @endphp
 
-<div x-cloak :class="{'block': open, 'hidden': !open}" class="border-t-2 border-theme-secondary-200 {{ $breakpointClass }}">
-    <div class="pt-2 pb-4 rounded-b-lg">
+<div
+    @class([
+        'border-t-2 border-theme-secondary-200',
+        'fixed bottom-0 top-21 w-full pointer-events-none',
+        $breakpointClass
+    ])
+    :class="{
+        block: open,
+        hidden: !open,
+    }"
+    x-cloak
+>
+    <div class="overflow-y-auto max-h-full pointer-events-auto bg-white pt-2 pb-4 rounded-b-lg">
         @if(isset($navbarNotificationsMobile) || isset($notifications))
             <div class="flex justify-center items-center py-0.5 px-2 my-4 mx-8 rounded border shadow-sm md:hidden border-theme-secondary-300">
                 @isset($navbarNotificationsMobile)

--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -17,8 +17,7 @@
 
 <div
     @class([
-        'border-t-2 border-theme-secondary-200',
-        'fixed bottom-0 top-21 w-full pointer-events-none',
+        'border-t-2 border-theme-secondary-200 fixed bottom-0 top-21 w-full pointer-events-none',
         $breakpointClass
     ])
     :class="{


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1u471fb

- adds shadow based on figma (there wasn't an already existing shadow setup based on what was in the designs)
- adds scrolling to mobile (e.g. for when the dropdown is open and too tall for the device)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
