### PR TITLE
refactor: add dark mode for disabled tags

### DIFF
--- a/resources/assets/css/_forms.css
+++ b/resources/assets/css/_forms.css
@@ -300,8 +300,12 @@ input[type="password"]::-ms-reveal {
 }
 
 .disabled-tags-input .tags-input-focus {
-    @apply border-theme-secondary-200;
+    @apply border-theme-secondary-200 dark:border-theme-secondary-800;
     box-shadow: 0 0 0 1px var(--theme-color-secondary-200);
+}
+
+.dark .disabled-tags-input .tags-input-focus {
+    box-shadow: 0 0 0 1px var(--theme-color-secondary-800);
 }
 
 .disabled-tags-input .taggle > .close {
@@ -312,7 +316,7 @@ input[type="password"]::-ms-reveal {
 .disabled-tags-input .taggle_list,
 .disabled-tags-input .taggle_placeholder,
 .disabled-tags-input > div {
-    @apply bg-theme-secondary-100;
+    @apply bg-theme-secondary-100 dark:bg-theme-secondary-900;
 }
 
 .disabled-tags-input:not(.disabled-tags-input-add) .taggle_list .taggle {


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1wu12bf

As part of [this](https://github.com/ArkEcosystem/marketsquare.io/pull/2563) MSQ PR, this adds a couple of dark mode styles to the `disabled-tags-input` class.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
