### PR TITLE
refactor: dark mode for 'show more' button on tile selection

### DIFF
--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -75,7 +75,7 @@
 
     @if (! $hiddenOptions && count($options) > ($mobileShowRows * 2))
         <div
-            class="py-3 font-semibold text-center rounded sm:hidden bg-theme-primary-100 text-theme-primary-600"
+            class="py-3 font-semibold text-center rounded sm:hidden button-secondary cursor-pointer"
             x-bind:class="{ hidden: ! mobileHidden }"
             @click="mobileHidden = false"
         >

--- a/resources/views/inputs/tile-selection.blade.php
+++ b/resources/views/inputs/tile-selection.blade.php
@@ -75,7 +75,7 @@
 
     @if (! $hiddenOptions && count($options) > ($mobileShowRows * 2))
         <div
-            class="py-3 font-semibold text-center rounded sm:hidden button-secondary cursor-pointer"
+            class="py-3 font-semibold text-center rounded cursor-pointer sm:hidden button-secondary"
             x-bind:class="{ hidden: ! mobileHidden }"
             @click="mobileHidden = false"
         >


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1p846jt

This PR add dark mode support for the tile-selection 'show more' button. Noticed when registering a project on MSQ.

To test with MSQ, require this branch, run yarn prod, and start to register a new project with a browser window of <640.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
