### PR TITLE
fix: add transition to tile link icon

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -418,7 +418,7 @@
 }
 
 .tile-link-icon {
-    @apply dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200;
+    @apply transition-default dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200;
 }
 
 .tile-link-title {

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -418,7 +418,7 @@
 }
 
 .tile-link-icon {
-    @apply transition-default dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200;
+    @apply transition-default hover:text-white dark:text-theme-secondary-600 dark:group-hover:text-theme-secondary-200;
 }
 
 .tile-link-title {


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1p87gj9

tile-link-icon was changing color immediately on hover - this add a transition inline with the background change

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
