### PR TITLE
refactor: accept custom name selector on modals

### DIFF
--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -26,7 +26,7 @@
     tabindex="0"
     @endif
     x-show="shown"
-    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
+    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
 >
 
     <div class="fixed inset-0 opacity-75 dark:opacity-50 bg-theme-secondary-900 dark:bg-theme-secondary-800"></div>

--- a/resources/views/js-modal.blade.php
+++ b/resources/views/js-modal.blade.php
@@ -15,7 +15,7 @@
 <div
     {{ $attributes }}
     x-ref="modal"
-    data-modal
+    data-modal="{{ $name }}"
     x-cloak
     @if($init)
     x-data="Modal.alpine({{ $xData }}, '{{ $name }}')"
@@ -26,7 +26,7 @@
     tabindex="0"
     @endif
     x-show="shown"
-    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
+    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
 >
 
     <div class="fixed inset-0 opacity-75 dark:opacity-50 bg-theme-secondary-900 dark:bg-theme-secondary-800"></div>

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -3,6 +3,7 @@
     'class' => '',
     'style' => null,
     'widthClass' => 'max-w-2xl',
+    'name' => null,
     'title' => null,
     'titleClass' => 'inline-block pb-2 font-bold dark:text-theme-secondary-200',
     'buttons' => null,
@@ -18,13 +19,17 @@
 <div
     wire:ignore.self
     x-ref="modal"
-    data-modal
+    @if($name)
+        data-modal="{{ $name }}"
+    @else
+        data-modal
+    @endif
     x-data="Modal.livewire({{ $xData }})"
     x-init="init"
     @if(!$closeButtonOnly && $wireClose)
         @mousedown.self="$wire.{{ $wireClose }}()"
     @endif
-    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
+    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
     @if(!$closeButtonOnly && $escToClose)
         wire:keydown.escape="{{ $wireClose }}"
         tabindex="0"

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -29,7 +29,7 @@
     @if(!$closeButtonOnly && $wireClose)
         @mousedown.self="$wire.{{ $wireClose }}()"
     @endif
-    class="fixed inset-0 z-50 flex overflow-y-auto md:py-10 md:px-8"
+    class="flex overflow-y-auto fixed inset-0 z-50 md:py-10 md:px-8"
     @if(!$closeButtonOnly && $escToClose)
         wire:keydown.escape="{{ $wireClose }}"
         tabindex="0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Dependant of https://github.com/ArkEcosystem/marketsquare.io/pull/2530
Related to: https://app.clickup.com/t/1qa4wyq

The modal now adds the name so it can be used as selector on dusk tests

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
