### PR TITLE
refactor: use same header component for 2fa page as login and register

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -14,12 +14,7 @@
 @endsection
 
 @section('content')
-    <div class="py-8 w-full bg-theme-secondary-100">
-        <div class="container mx-auto">
-            <h1 class="mx-4 text-2xl font-bold text-center md:mx-8 md:text-4xl xl:mx-16 text-theme-secondary-900">@lang('ui::auth.two-factor.page_header')</h1>
-            <p class="mx-4 mt-4 font-semibold text-center md:mx-8 xl:mx-16 text-theme-secondary-700">@lang('ui::auth.two-factor.page_description')</p>
-        </div>
-    </div>
+    <x:ark-fortify::component-heading :title="trans('ui::auth.two-factor.page_header')" :description="trans('ui::auth.two-factor.page_description')" />
 
     <div x-data="{ recovery: @json($errors->has('recovery_code')) }" x-cloak>
         @include('ark-fortify::auth.two-factor.form')


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1tfab68

This change replaces the custom header used in `two-factor-challenge.blade.php` with the `component-heading.blade.php` component which is used in signup and signin.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
