### PR TITLE
fix: adjust checkbox color

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -366,7 +366,7 @@
 }
 
 .tile-selection-checkbox {
-    @apply absolute top-2 right-2;
+    @apply absolute top-2 right-2 cursor-pointer;
 }
 .tile-selection-checkbox,
 .tile-selection-checkbox:focus {

--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -378,7 +378,7 @@
 }
 .tile-selection-select-all-checkbox:checked,
 .tile-selection-checkbox:checked {
-    @apply border-theme-success-500 bg-theme-success-500 dark:border-theme-success-600 dark:bg-theme-success-600;
+    @apply border-theme-success-600 bg-theme-success-600 dark:border-theme-success-600 dark:bg-theme-success-600;
 }
 
 /** Tile Links **/

--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -120,7 +120,7 @@
                                 <button
                                     type="button"
                                     wire:click.stop="$emit('setNotification', '{{ $notification->id }}')"
-                                    class="flex justify-center items-center w-5 h-5 text-white rounded cursor-pointer box-border bg-theme-success-500"
+                                    class="flex justify-center items-center w-5 h-5 text-white rounded cursor-pointer box-border bg-theme-success-600"
                                 >
                                     <x-ark-icon name="checkmark" size="2xs" />
                                 </button>


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1tmzztg

Adjust the checkbox color from success-500 to success-600. I *think* I got them all.

Note this also add a pointer cursor to the tile selection checkbox which was missing previously (you can test by selecting platforms when creating a project in MSQ).

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
