### PR TITLE
refactor: dropdown closed button class

### DIFF
--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -2,7 +2,7 @@
     'dropdownProperty'       => 'dropdownOpen',
     'dropdownContentClasses' => 'bg-white rounded-xl shadow-lg dark:bg-theme-secondary-800 dark:text-theme-secondary-200',
     'buttonClassExpanded'    => 'text-theme-primary-500',
-    'buttonClassContracted'  => '',
+    'buttonClassClosed'      => '',
     'buttonClass'            => 'text-theme-secondary-400 hover:text-theme-primary-500',
     'dropdownClasses'        => 'w-40',
     'dropdownOriginClass'    => 'origin-top-right',
@@ -49,7 +49,7 @@
     <div>
         <button
             type="button"
-            :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }}, '{{ $buttonClassContracted }}' : !{{ $dropdownProperty }} }"
+            :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }}, '{{ $buttonClassClosed }}' : !{{ $dropdownProperty }} }"
             class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
             @if($disabled) disabled @else @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif
             @if($buttonTooltip) data-tippy-content="{{ $buttonTooltip }}" @endif

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -2,6 +2,7 @@
     'dropdownProperty'       => 'dropdownOpen',
     'dropdownContentClasses' => 'bg-white rounded-xl shadow-lg dark:bg-theme-secondary-800 dark:text-theme-secondary-200',
     'buttonClassExpanded'    => 'text-theme-primary-500',
+    'buttonClassContracted'  => '',
     'buttonClass'            => 'text-theme-secondary-400 hover:text-theme-primary-500',
     'dropdownClasses'        => 'w-40',
     'dropdownOriginClass'    => 'origin-top-right',
@@ -48,7 +49,7 @@
     <div>
         <button
             type="button"
-            :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }} }"
+            :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }}, '{{ $buttonClassContracted }}' : !{{ $dropdownProperty }} }"
             class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
             @if($disabled) disabled @else @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif
             @if($buttonTooltip) data-tippy-content="{{ $buttonTooltip }}" @endif


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

related to Sam feedback here https://app.clickup.com/t/1xwbkk7

Adds the `buttonClassContracted` option in the dropdown to add classes that are only used when the dropdown is closed

Dependant of: 



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
