### PR TITLE
fix: compress image size

### DIFF
--- a/resources/assets/js/compress-image.js
+++ b/resources/assets/js/compress-image.js
@@ -114,11 +114,10 @@ const CompressImage = (
             height: $height ? undefined : $height,
             success: (file) => this.onSuccess(file),
             error: (error) => this.onError(error),
-        }
+        };
 
         new Compressor(file, params);
     },
-
 });
 
 window.CompressImage = CompressImage;

--- a/resources/assets/js/compress-image.js
+++ b/resources/assets/js/compress-image.js
@@ -101,9 +101,8 @@ const CompressImage = (
         throw new Error(error.message);
     },
 
-    async loadCompressor(file) {
-        let size = await this.getNaturalSize(file);
-        new Compressor(file, {
+    loadCompressor(file) {
+        let params = {
             quality: $quality,
             checkOrientation: parseInt($maxFileSize) <= 10,
             convertSize: $disableConvertSize ? "Infinity" : $convertSize,
@@ -111,29 +110,15 @@ const CompressImage = (
             maxHeight: $maxHeight,
             minWidth: $minWidth,
             minHeight: $minHeight,
-            width: $width ? $width : size.width,
-            height: $height ? $height : size.height,
+            width: $width ? undefined : $width,
+            height: $height ? undefined : $height,
             success: (file) => this.onSuccess(file),
             error: (error) => this.onError(error),
-        });
+        }
+
+        new Compressor(file, params);
     },
 
-    getNaturalSize(file) {
-        return new Promise((resolve) => {
-            let reader = new FileReader();
-            reader.onload = function (e) {
-                let img = new Image();
-                img.src = e.target.result;
-                img.onload = function () {
-                    resolve({
-                        width: img.width,
-                        height: img.height,
-                    });
-                };
-            };
-            reader.readAsDataURL(file);
-        });
-    },
 });
 
 window.CompressImage = CompressImage;

--- a/resources/assets/js/compress-image.js
+++ b/resources/assets/js/compress-image.js
@@ -101,7 +101,8 @@ const CompressImage = (
         throw new Error(error.message);
     },
 
-    loadCompressor(file) {
+    async loadCompressor(file) {
+        let size = await this.getNaturalSize(file);
         new Compressor(file, {
             quality: $quality,
             checkOrientation: parseInt($maxFileSize) <= 10,
@@ -110,12 +111,29 @@ const CompressImage = (
             maxHeight: $maxHeight,
             minWidth: $minWidth,
             minHeight: $minHeight,
-            width: $width,
-            height: $height,
+            width: $width ? $width : size.width,
+            height: $height ? $height : size.height,
             success: (file) => this.onSuccess(file),
             error: (error) => this.onError(error),
         });
     },
+
+    getNaturalSize(file) {
+        return new Promise((resolve) => {
+            let reader = new FileReader()
+            reader.onload = function (e) {
+                let img = new Image()
+                img.src = e.target.result
+                img.onload = function () {
+                    resolve({
+                        width: img.width,
+                        height: img.height
+                    })
+                }
+            }
+            reader.readAsDataURL(file)
+        })
+    }
 });
 
 window.CompressImage = CompressImage;

--- a/resources/assets/js/compress-image.js
+++ b/resources/assets/js/compress-image.js
@@ -102,7 +102,7 @@ const CompressImage = (
     },
 
     loadCompressor(file) {
-        let params = {
+        const params = {
             quality: $quality,
             checkOrientation: parseInt($maxFileSize) <= 10,
             convertSize: $disableConvertSize ? "Infinity" : $convertSize,
@@ -110,8 +110,8 @@ const CompressImage = (
             maxHeight: $maxHeight,
             minWidth: $minWidth,
             minHeight: $minHeight,
-            width: $width ? undefined : $width,
-            height: $height ? undefined : $height,
+            width: $width ?? undefined,
+            height: $height ?? undefined,
             success: (file) => this.onSuccess(file),
             error: (error) => this.onError(error),
         };

--- a/resources/views/inputs/upload-image-collection.blade.php
+++ b/resources/views/inputs/upload-image-collection.blade.php
@@ -26,8 +26,8 @@
         {{ $minHeight }},
         {{ $maxWidth }},
         {{ $maxHeight }},
-        '{{ $width ?? $maxWidth }}',
-        '{{ $height ?? $maxHeight }}',
+        '{{ $width }}',
+        '{{ $height }}',
         '{{ $maxFilesize }}',
         {{ $quality }}
     )"


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/21zxnhy

The new version of compressorjs has some odd functionality which means if we pass in a minWidth and maxWidth, it will try to resize the image to one of them. This is causing issues for image uploads in MSQ.

~~The solution here is to get the natual width/height of an image and pass those values into compressorjs.~~

The *new* solution here is to just set the width/height to `undefined` if they are not passed in. compressorjs seems to be like that.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
