### PR TITLE
fix: OTP required validation message

### DIFF
--- a/src/Fortify/Components/TwoFactorAuthenticationForm.php
+++ b/src/Fortify/Components/TwoFactorAuthenticationForm.php
@@ -39,7 +39,8 @@ class TwoFactorAuthenticationForm extends Component
     public string $confirmedPassword = '';
 
     protected $messages = [
-        'state.otp.digits' => 'One Time Password must be :digits digits.',
+        'state.otp.required' => 'Please provide an OTP',
+        'state.otp.digits'   => 'One Time Password must be :digits digits.',
     ];
 
     public function mount(): void


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1y8m9ag

This PR adds a custom message to the required validation when entering an OTP. 

To test, require this branch on MSQ, go to setting and try to enable 2fa without entering a code in, you should see a custom tooltip error.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
