### PR TITLE
fix: dark mode border color in 2fa mobile view

### DIFF
--- a/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/resources/views/profile/two-factor-authentication-form.blade.php
@@ -84,7 +84,7 @@
                 />
             </div>
 
-            <div class="flex pt-8 mt-8 border-t sm:justify-end sm:pt-0 sm:border-t-0 border-theme-secondary-300">
+            <div class="flex pt-8 mt-8 border-t sm:justify-end sm:pt-0 sm:border-t-0 border-theme-secondary-300 dark:border-theme-secondary-800">
                 <button
                     type="button"
                     class="w-full sm:w-auto button-secondary"


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/22wjvpy

To test, go to account/settings in MSQ. resize browser to mobile so the 2fa verification code is underneath the QR code, and check border color.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
