### PR TITLE
fix: pagination-url icons

### DIFF
--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -55,8 +55,7 @@
             <a class="flex" href="{{ $paginator->url(1) }}">
                 <div class="flex items-center h-full button-secondary pagination-button-mobile">
                     <div class="flex items-center">
-                        <x-ark-icon class="inline-block lg:hidden" name="arrows.double-chevron-left" size="xs" />
-                        <span class="hidden lg:flex">@lang('ui::generic.previous')</span>
+                        <x-ark-icon name="arrows.double-chevron-left" size="xs" />
                     </div>
                 </div>
             </a>
@@ -65,23 +64,23 @@
         @if($paginator->onFirstPage())
             <div class="flex items-center button-generic button-disabled">
                 <div class="flex items-center">
-                    <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                     <span class="hidden lg:flex lg:ml-2">@lang('ui::generic.previous')</span>
+                    <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                 </div>
             </div>
         @else
             <a class="flex" href="{{ $paginator->previousPageUrl() }}">
                 <div class="flex items-center h-full button-secondary pagination-button-mobile">
                     <div class="flex items-center">
-                        <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                         <span class="hidden lg:flex lg:ml-2">@lang('ui::generic.previous')</span>
+                        <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                     </div>
                 </div>
             </a>
         @endif
 
         <div class="relative">
-            <form x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 pagination-form-desktop dark:bg-theme-secondary-800">
+            <form x-cloak x-show="search" name="searchForm" type="get" class="flex overflow-hidden absolute left-0 z-10 px-2 w-full h-full rounded bg-theme-primary-100 pagination-form-desktop dark:bg-theme-secondary-800">
                 <input
                     x-ref="search"
                     x-model.number="page"

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -54,9 +54,10 @@
         @else
             <a class="flex" href="{{ $paginator->url(1) }}">
                 <div class="flex items-center h-full button-secondary pagination-button-mobile">
-                    <span class="flex items-center">
-                        <x-ark-icon name="arrows.double-chevron-left" size="xs" />
-                    </span>
+                    <div class="flex items-center">
+                        <x-ark-icon class="inline-block lg:hidden" name="arrows.double-chevron-left" size="xs" />
+                        <span class="hidden lg:flex">@lang('ui::generic.previous')</span>
+                    </div>
                 </div>
             </a>
         @endif
@@ -64,6 +65,7 @@
         @if($paginator->onFirstPage())
             <div class="flex items-center button-generic button-disabled">
                 <div class="flex items-center">
+                    <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                     <span class="hidden lg:flex lg:ml-2">@lang('ui::generic.previous')</span>
                 </div>
             </div>
@@ -71,6 +73,7 @@
             <a class="flex" href="{{ $paginator->previousPageUrl() }}">
                 <div class="flex items-center h-full button-secondary pagination-button-mobile">
                     <div class="flex items-center">
+                        <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-left" size="xs" />
                         <span class="hidden lg:flex lg:ml-2">@lang('ui::generic.previous')</span>
                     </div>
                 </div>
@@ -152,13 +155,15 @@
                 <div class="flex items-center h-full button-secondary pagination-button-mobile">
                     <div class="flex items-center">
                         <span class="hidden lg:flex lg:mr-2">@lang('ui::generic.next')</span>
+                        <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-right" size="xs" />
                     </div>
                 </div>
             </a>
         @else
             <div class="flex items-center button-generic button-disabled">
                 <div class="flex items-center">
-                    <span class="hidden lg:flex lg:mr-2">@lang('ui::generic.next')</span>
+                    <span class="hidden lg:flex">@lang('ui::generic.next')</span>
+                    <x-ark-icon class="inline-block lg:hidden" name="arrows.chevron-right" size="xs" />
                 </div>
             </div>
         @endif


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/1ve57ru

The PR adds the missing chevron left and right icons to the `pagination-url.blade.php` component.

Note I also noticed a flash of the search form on page load so added `x-cloak` to that.

This can be tested in deployer by seeding the db and going to a tokens activity page. The seed does not create enough activity items to trigger the pagination so I temporarily set it to a small number in `TokenActivityController.php` (`->paginate(2)`)

Required for [this PR](https://github.com/ArkEcosystem/deployer.io/pull/1003)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
