### PR TITLE
refactor: fix axes name on chart.js script

### DIFF
--- a/resources/assets/js/chart.js
+++ b/resources/assets/js/chart.js
@@ -206,11 +206,11 @@ const CustomChart = (
                     axis: "x",
                 },
                 scales: {
-                    y: {
+                    yAxes: {
                         ...this.loadYAxes()[0],
                         position: "right",
                     },
-                    x: {
+                    xAxes: {
                         display: grid,
                         type: "category",
                         labels: labels,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/23t2m9q

The plugin try to access the axes in the `options.scales.{}` object with `xAxes` and `yAxes` but in the script they are defined with `x` and `y`.
Changing their names to `xAxes` and `yAxes` solve the issue.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
