### PR TITLE
fix: use lowercase t for team on contact page

### DIFF
--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'contact' => [
         'title'               => 'Contact Us',
-        'subtitle'            => 'Have questions? Contact our Team for additional support.',
+        'subtitle'            => 'Have questions? Contact our team for additional support.',
         'message_placeholder' => 'How can we help?',
         'form'                => [
             'title'       => 'Contact Our Team',


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/237texy

The deployer support page design has a lowercase 't' in 'team'.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
