### PR TITLE
refactor: have registration default to name and fix password input

### DIFF
--- a/resources/views/auth/register-form.blade.php
+++ b/resources/views/auth/register-form.blade.php
@@ -55,6 +55,7 @@
             :password-rules="$passwordRules"
             is-typing="isTyping"
             rules-wrapper-class="grid grid-cols-1 gap-4 my-4"
+            @typing="isTyping=true"
         >
             <x-ark-password-toggle
                 model="password"
@@ -62,7 +63,6 @@
                 :label="trans('ui::forms.password')"
                 autocomplete="new-password"
                 class="w-full"
-                @keydown="isTyping=true"
                 :errors="$errors"
             />
         </x:ark-fortify::password-rules>

--- a/src/Fortify/Components/RegisterForm.php
+++ b/src/Fortify/Components/RegisterForm.php
@@ -32,7 +32,6 @@ class RegisterForm extends Component
 
     protected array $requiredProperties = [
         'name',
-        'username',
         'email',
         'password',
         'password_confirmation',
@@ -41,10 +40,9 @@ class RegisterForm extends Component
 
     public function mount()
     {
-        $this->name     = old('name', '');
-        $this->username = old('username', '');
-        $this->email    = old('email', '');
-        $this->terms    = old('terms', false) === true;
+        $this->name      = old('name', '');
+        $this->email     = old('email', '');
+        $this->terms     = old('terms', false) === true;
 
         $this->formUrl = request()->fullUrl();
 

--- a/src/Fortify/Components/RegisterForm.php
+++ b/src/Fortify/Components/RegisterForm.php
@@ -40,9 +40,9 @@ class RegisterForm extends Component
 
     public function mount()
     {
-        $this->name      = old('name', '');
-        $this->email     = old('email', '');
-        $this->terms     = old('terms', false) === true;
+        $this->name  = old('name', '');
+        $this->email = old('email', '');
+        $this->terms = old('terms', false) === true;
 
         $this->formUrl = request()->fullUrl();
 


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/23ypqp6

This PR makes changes to the registration form used for registering an account. Previously we have `name` and `username`, we only use both on MSQ which uses custom components anyway. I have removed `username` as a required parameter since deployer uses only `name` in the db (but calls it username in the UI - see [here](https://github.com/ArkEcosystem/deployer.io/pull/1040) for solution to that).

Also included is a fix to the password rules in the UI.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
