### PR TITLE
fix: external link unclickable if request processed after open

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -22,10 +22,7 @@
                 localStorage.setItem('has_disabled_link_warning', true)
             }
 
-            $nextTick(() => {
-                this.hide();
-                window.open(this.url, '_blank');
-            });
+            this.hide();
         },
     }"
     init
@@ -70,6 +67,7 @@
             class="cursor-pointer button-primary"
             :href="url"
             @click="followLink()"
+            data-safe-external="true"
         >
             @lang('actions.follow_link')
         </a>

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -22,7 +22,10 @@
                 localStorage.setItem('has_disabled_link_warning', true)
             }
 
-            this.hide();
+            $nextTick(() => {
+                this.hide();
+                window.open(this.url, '_blank');
+            });
         },
     }"
     init


### PR DESCRIPTION
## Summary
https://app.clickup.com/t/1z0m205

The issue was due to the polling of the `Alert` component. Because of the Livewire hook for this to work, `initExternalLinkConfirm();` will be executed every 2 seconds. Because of that the (confirmed) link in the modal will also get a `data-external-link-confirm="true"` again.

Solved by adding `data-safe-external="true"` to the link in the modal.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
