### PR TITLE
refactor: allow dropdown zindex override

### DIFF
--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -5,6 +5,7 @@
     'buttonClassClosed'      => '',
     'buttonClass'            => 'text-theme-secondary-400 hover:text-theme-primary-500',
     'dropdownClasses'        => 'w-40',
+    'zIndex'                 => 'z-10',
     'dropdownOriginClass'    => 'origin-top-right',
     'wrapperClass'           => 'absolute inline-block top-0 right-0 text-left',
     'fullScreen'             => false,
@@ -79,7 +80,12 @@
         x-transition:leave="transition ease-in duration-75"
         x-transition:leave-start="transform opacity-100 scale-100"
         x-transition:leave-end="transform opacity-0 scale-95"
-        class="absolute right-0 mt-2 z-10 dropdown {{ $dropdownClasses }} {{ $fullScreen ? 'w-screen -mx-8 md:w-auto md:mx-0' : '' }}"
+        @class([
+            'absolute right-0 mt-2 dropdown',
+            $dropdownClasses,
+            $zIndex,
+            'w-screen -mx-8 md:w-auto md:mx-0' => $fullScreen,
+        ])
         @if ($height) data-height="{{ $height }}" @endif
     >
         <div class="{{ $dropdownContentClasses }}" x-cloak>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/21w7ru4

Required by https://github.com/ArkEcosystem/nodem/pull/382

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
