### PR TITLE
refactor: reduce link collection padding

### DIFF
--- a/resources/views/link-collection.blade.php
+++ b/resources/views/link-collection.blade.php
@@ -9,16 +9,16 @@
         <div class="py-1">
             <a
                 href="{{ $link[$urlProperty] }}"
-                class="flex pl-5 w-full h-full no-underline rounded border-2 group transition-default border-theme-primary-100 hover:bg-theme-primary-700 hover:border-theme-primary-700"
+                class="flex pl-3 w-full h-full no-underline rounded border-2 group transition-default border-theme-primary-100 hover:bg-theme-primary-700 hover:border-theme-primary-700"
                 @if ($isExternal)
                     target="_blank"
                     rel="noopener nofollow noreferrer"
                 @endif
             >
                 <div class="flex flex-1 justify-between items-center group-hover:text-white text-theme-primary-600">
-                    <span class="py-2">{{ $link['name'] }}</span>
+                    <span class="py-2 pr-3">{{ $link['name'] }}</span>
 
-                    <div class="flex justify-center items-center -my-px w-11 h-full group-hover:bg-transparent bg-theme-primary-100 transition-default">
+                    <div class="flex justify-center items-center -my-px w-8 h-full group-hover:bg-transparent bg-theme-primary-100 transition-default">
                         <x-ark-icon name="arrows.chevron-right" size="sm" />
                     </div>
                 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Reduces padding for the link collection to be like the middle option here

<img width="326" alt="image" src="https://user-images.githubusercontent.com/35610748/161227735-5afc88c3-7655-4866-9645-cce1113e4269.png">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
