### PR TITLE
refactor: make cookies backwards compatible

### DIFF
--- a/resources/assets/js/cookieconsent.js
+++ b/resources/assets/js/cookieconsent.js
@@ -1662,6 +1662,22 @@
                 saved_cookie_content = JSON.parse(
                     _getCookie(_config.cookie_name, "one", true) || "{}"
                 );
+
+                // Backwards compatibility
+                if (saved_cookie_content["levels"] !== undefined) {
+                    saved_cookie_content["categories"] = saved_cookie_content["levels"];
+                    delete saved_cookie_content["levels"];
+
+                    // Delete outdated cookies
+                    _eraseCookies([_config.cookie_name], "/", [_config.cookie_domain, "."+_config.cookie_domain]);
+
+                    // Re-save it so it's updated to the new categories approach
+                    _setCookie(
+                        _config.cookie_name,
+                        JSON.stringify(saved_cookie_content)
+                    );
+                }
+
                 cookie_consent_accepted =
                     saved_cookie_content["categories"] !== undefined;
 

--- a/resources/assets/js/cookieconsent.js
+++ b/resources/assets/js/cookieconsent.js
@@ -1665,11 +1665,15 @@
 
                 // Backwards compatibility
                 if (saved_cookie_content["levels"] !== undefined) {
-                    saved_cookie_content["categories"] = saved_cookie_content["levels"];
+                    saved_cookie_content["categories"] =
+                        saved_cookie_content["levels"];
                     delete saved_cookie_content["levels"];
 
                     // Delete outdated cookies
-                    _eraseCookies([_config.cookie_name], "/", [_config.cookie_domain, "."+_config.cookie_domain]);
+                    _eraseCookies([_config.cookie_name], "/", [
+                        _config.cookie_domain,
+                        "." + _config.cookie_domain,
+                    ]);
 
                     // Re-save it so it's updated to the new categories approach
                     _setCookie(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2pbubxb

Make cookies work with the old `levels` property by adjusting them if they were found. This ensures that existing viewers will not run into issues if they had the old cookie type set on their machine

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
