### PR TITLE
fix: prevent images from being treated as pages

### DIFF
--- a/src/Documentation/Document.php
+++ b/src/Documentation/Document.php
@@ -125,7 +125,7 @@ class Document extends Model
         $documents = [];
 
         foreach ($storage->allFiles() as $file) {
-            if (Str::endsWith($file, '.json')) {
+            if (!str_ends_with($file, '.php')) {
                 continue;
             }
 

--- a/src/Documentation/Document.php
+++ b/src/Documentation/Document.php
@@ -125,7 +125,7 @@ class Document extends Model
         $documents = [];
 
         foreach ($storage->allFiles() as $file) {
-            if (!str_ends_with($file, '.php')) {
+            if (! str_ends_with($file, '.php')) {
                 continue;
             }
 


### PR DESCRIPTION
Sometimes images can slip into the discovery if they are stored in the same directory as the actual docs.