### PR TITLE
fix: check for exact matches by slug

### DIFF
--- a/resources/views/pages/contact.blade.php
+++ b/resources/views/pages/contact.blade.php
@@ -33,7 +33,7 @@
                 </div>
             </div>
 
-            <div class="pb-8 border-b border-dashed border-theme-secondary-300 dark:border-theme-secondary-800">
+            <div>
                 <h3>{{ $additionalTitle }}</h3>
 
                 <div class="mt-4 paragraph-description">
@@ -56,19 +56,21 @@
                 </div>
             </div>
 
-            <div class="space-y-3 text-theme-secondary-900 dark:text-theme-secondary-200">
-                <div class="font-bold">@lang('ui::pages.contact.social.subtitle')</div>
+            @if (count($contactNetworks) > 0)
+                <div class="pt-8 space-y-3 border-t border-dashed text-theme-secondary-900 border-theme-secondary-300 dark:text-theme-secondary-200 dark:border-theme-secondary-800">
+                    <div class="font-bold">@lang('ui::pages.contact.social.subtitle')</div>
 
-                <div class="flex space-x-3 text-theme-primary-600">
-                    @foreach($contactNetworks as $name => $url)
-                        <x-ark-social-square
-                            hover-class="{{ $socialIconHoverClass }}"
-                            :url="$url"
-                            :icon="$name"
-                        />
-                    @endforeach
+                    <div class="flex space-x-3 text-theme-primary-600">
+                        @foreach($contactNetworks as $name => $url)
+                            <x-ark-social-square
+                                hover-class="{{ $socialIconHoverClass }}"
+                                :url="$url"
+                                :icon="$name"
+                            />
+                        @endforeach
+                    </div>
                 </div>
-            </div>
+            @endif
         </div>
 
         <div class="flex flex-col flex-1 lg:pl-6" x-data="{ subject: '{{ old('subject', $subject) }}' }">

--- a/src/Documentation/Document.php
+++ b/src/Documentation/Document.php
@@ -125,7 +125,7 @@ class Document extends Model
         $documents = [];
 
         foreach ($storage->allFiles() as $file) {
-            if (Str::endsWith($file, '.json')) {
+            if (! str_ends_with($file, '.php')) {
                 continue;
             }
 
@@ -182,7 +182,7 @@ class Document extends Model
 
             return static::query()
                 ->where('type', $this->type)
-                ->where('slug', 'like', '%'.$matches[$callback($index)]['link'].'%')
+                ->where('slug', $matches[$callback($index)]['link'])
                 ->first();
         });
     }


### PR DESCRIPTION
For example on https://docs.payvo.com/docs/wallet/support/security there is no neighbour following the security page but because of how the lookup works it picks up the https://docs.payvo.com/docs/wallet/profiles/contacts page because that does exist locally.