### PR TITLE
fix: ensure the document model has properties

### DIFF
--- a/src/Documentation/Document.php
+++ b/src/Documentation/Document.php
@@ -52,12 +52,12 @@ class Document extends Model
 
     public function hasPrevious(): bool
     {
-        return ! empty($this->previous());
+        return ! empty($this->previous()?->toArray());
     }
 
     public function hasNext(): bool
     {
-        return ! empty($this->next());
+        return ! empty($this->next()?->toArray());
     }
 
     public function url(): string


### PR DESCRIPTION
It's possible to get a model instance that is empty so we need to check that the array representation isn't because the model itself will evaluate to not being empty but the array will evaluate to being empty.