### PR TITLE
refactor: allow favicon data to be passed as slot

### DIFF
--- a/resources/assets/css/themes/_navy.css
+++ b/resources/assets/css/themes/_navy.css
@@ -5,7 +5,7 @@
     --theme-color-primary-200: #b6d7f8;
     --theme-color-primary-300: #8ac0f6;
     --theme-color-primary-400: #5ca4ec;
-    --theme-color-primary-500: #4381c0;
+    --theme-color-primary-500: #154a82;
     --theme-color-primary-600: #235b95;
     --theme-color-primary-700: #154a82;
     --theme-color-primary-800: #073769;

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -53,7 +53,7 @@
         x-ref="nav"
         @class([
         	'fixed top-0 z-30 w-full border-b dark:bg-theme-secondary-900 dark:border-theme-secondary-800 transition duration-400',
-        	'border-theme-primary-700 bg-theme-primary-600 inverted:bg-white inverted:border-transparent inverted:shadow-header-smooth' => $inverted,
+        	'border-theme-primary-500 bg-theme-primary-600 inverted:bg-white inverted:border-transparent inverted:shadow-header-smooth' => $inverted,
         	'bg-white border-theme-secondary-300' => ! $inverted,
         ])
         dusk="navigation-bar"

--- a/resources/views/pages/includes/layout-head.blade.php
+++ b/resources/views/pages/includes/layout-head.blade.php
@@ -19,13 +19,17 @@
     @endif
 
     <!-- Favicon -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="{{ $maskIconColor }}">
-    <meta name="msapplication-TileColor" content="{{ $microsoftTileColor }}">
-    <meta name="theme-color" content="{{ $themeColor }}">
+    @unless (isset($favicons))
+        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+        <link rel="manifest" href="/site.webmanifest">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="{{ $maskIconColor }}">
+        <meta name="msapplication-TileColor" content="{{ $microsoftTileColor }}">
+        <meta name="theme-color" content="{{ $themeColor }}">
+    @else
+        {{ $favicons }}
+    @endunless
 
     <!-- Meta --->
     <x-ark-metadata-tags>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This PR allows you to add the `favicons` slot to the component and manually specify all the favicon stuff. Good use case would be overriding which public directory the favicons are loaded from.

This PR also changes navy 500 color which is only used in a border between navbar and hero, to be consistent with red color (Slack).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
