### PR TITLE
refactor: hamburger menu & mobile separator paddings

### DIFF
--- a/resources/views/navbar/hamburger.blade.php
+++ b/resources/views/navbar/hamburger.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div class="flex items-center {{ $breakpointClass }}">
-    <button @click="open = !open" class="inline-flex relative justify-center items-center h-11 py-2 px-3 md:px-5 rounded-md transition ease-in-out hover:text-white duration-400 inverted:text-theme-secondary-900 inverted:hover:bg-theme-primary-100 inverted:hover:text-theme-primary-700 text-theme-primary-100 hover:bg-theme-primary-400">
+    <button @click="open = !open" class="inline-flex relative justify-center items-center py-2 px-3 h-11 rounded-md transition ease-in-out md:px-5 hover:text-white duration-400 inverted:text-theme-secondary-900 inverted:hover:bg-theme-primary-100 inverted:hover:text-theme-primary-700 text-theme-primary-100 hover:bg-theme-primary-400">
         <span :class="{ 'hidden': open, 'inline-flex': !open }">
             <x-ark-icon name="menu" />
         </span>

--- a/resources/views/navbar/hamburger.blade.php
+++ b/resources/views/navbar/hamburger.blade.php
@@ -19,7 +19,7 @@
 @endphp
 
 <div class="flex items-center {{ $breakpointClass }}">
-    <button @click="open = !open" class="inline-flex relative justify-center items-center py-2 px-5 h-11 rounded-md transition ease-in-out hover:text-white duration-400 inverted:text-theme-secondary-900 inverted:hover:bg-theme-primary-100 inverted:hover:text-theme-primary-700 text-theme-primary-100 hover:bg-theme-primary-400">
+    <button @click="open = !open" class="inline-flex relative justify-center items-center h-11 py-2 px-3 md:px-5 rounded-md transition ease-in-out hover:text-white duration-400 inverted:text-theme-secondary-900 inverted:hover:bg-theme-primary-100 inverted:hover:text-theme-primary-700 text-theme-primary-100 hover:bg-theme-primary-400">
         <span :class="{ 'hidden': open, 'inline-flex': !open }">
             <x-ark-icon name="menu" />
         </span>
@@ -30,7 +30,7 @@
     </button>
 
     <span @class([
-    	'block pr-7 ml-7 h-7 border-l transition duration-400',
+    	'block pr-6 md:pr-8 ml-3 h-7 border-l transition duration-400',
     	$invertedSeparator,
     ])></span>
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/27cgg69 (needs another PR for the project's repo when foundation merged)

Separator left/right padding between button and the hamburger menu:
- 24px on each side
- 32px on md screen, as per design

Hamburger menu hover state:
- 12px horizontal padding
- 20px horizontal padding on md screen

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
