### PR TITLE
fix: navbar hamburger padding

### DIFF
--- a/resources/views/navbar/hamburger.blade.php
+++ b/resources/views/navbar/hamburger.blade.php
@@ -27,7 +27,7 @@
     <button
         @click="open = !open"
         @class([
-            'inline-flex relative justify-center items-center py-2 px-5 h-11 rounded-md transition duration-400 ease-in-out',
+            'inline-flex relative justify-center items-center py-2 px-3 h-11 rounded-md transition ease-in-out md:px-5 duration-400',
             $invertedColour,
         ])
     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://github.com/ArkEcosystem/laravel-foundation/pull/319 accidentally reverted the hamburger padding. This reverts that revert

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
