### PR TITLE
fix: pass additional navigation attributes to mobile link

### DIFF
--- a/resources/views/navbar/items/mobile.blade.php
+++ b/resources/views/navbar/items/mobile.blade.php
@@ -94,6 +94,7 @@
                     :name="$navItem['label']"
                     :params="$navItem['params'] ?? []"
                     :icon="isset($navItem['icon']) ? $navItem['icon'] : false"
+                    :attrs="$navItem['attributes'] ?? []"
                     :rounded="false"
                 />
             @endisset

--- a/resources/views/sidebar-link.blade.php
+++ b/resources/views/sidebar-link.blade.php
@@ -7,6 +7,7 @@
     'href' => null,
     'active' => false,
     'rounded' => true,
+    'attrs' => [],
 ])
 
 @php ($isCurrent = ($route && url()->full() === route($route, $params)))
@@ -30,6 +31,9 @@
             'text-theme-secondary-900 hover:text-theme-primary-600 dark:text-theme-secondary-200 dark:hover:text-theme-primary-600' => ! $isCurrent,
         ])
         dusk='navbar-item-{{ Str::slug($name) }}'
+        @foreach($attrs as $attribute => $attributeValue)
+            {{ $attribute }}="{{ $attributeValue }}"
+        @endforeach
         {{ $attributes->except(['href', 'class', 'dusk']) }}
     >
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/295ptju

Turns out, if you build navigation menu and set additional attributes, like `['target' => '_blank']`, this will not be propagated down to the mobile menu, only to desktop.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
