### PR TITLE
fix: read-more button not showing up

### DIFF
--- a/resources/assets/js/read-more.js
+++ b/resources/assets/js/read-more.js
@@ -6,27 +6,29 @@ const ReadOnly = ({ value }) => ({
         this.truncate();
     },
     truncate() {
-        const el = this.$root.querySelector(".read-more-content");
-
-        el.innerHTML = "";
-        el.appendChild(document.createTextNode(this.value));
-
-        if (!this.hasOverflow(el)) {
-            return;
-        }
-
-        let length = this.value.length;
-        do {
-            const a = this.value.substr(0, length);
-            const truncated = a + "...";
+        this.$nextTick(() => {
+            const el = this.$root.querySelector(".read-more-content");
 
             el.innerHTML = "";
-            el.appendChild(document.createTextNode(truncated));
+            el.appendChild(document.createTextNode(this.value));
 
-            length--;
+            if (!this.hasOverflow(el)) {
+                return;
+            }
 
-            this.showExpand = true;
-        } while (length > 1 && this.hasOverflow(el));
+            let length = this.value.length;
+            do {
+                const a = this.value.substr(0, length);
+                const truncated = a + "...";
+
+                el.innerHTML = "";
+                el.appendChild(document.createTextNode(truncated));
+
+                length--;
+
+                this.showExpand = true;
+            } while (length > 1 && this.hasOverflow(el));
+        })
     },
     showAll() {
         const el = this.$root.querySelector(".read-more-content");

--- a/resources/assets/js/read-more.js
+++ b/resources/assets/js/read-more.js
@@ -4,8 +4,8 @@ const ReadOnly = ({ value }) => ({
     showExpand: false,
     init() {
         this.$nextTick(() => {
-            this.truncate()
-        })
+            this.truncate();
+        });
     },
     truncate() {
         const el = this.$root.querySelector(".read-more-content");

--- a/resources/assets/js/read-more.js
+++ b/resources/assets/js/read-more.js
@@ -3,15 +3,11 @@ const ReadOnly = ({ value }) => ({
     showMore: false,
     showExpand: false,
     init() {
-        this.$nextTick(() => {
-            this.truncate();
-        });
+        this.truncate();
     },
     truncate() {
         const el = this.$root.querySelector(".read-more-content");
-        const expand = this.$root.querySelector(".read-more-expand");
 
-        expand.style.display = "none";
         el.innerHTML = "";
         el.appendChild(document.createTextNode(this.value));
 

--- a/resources/assets/js/read-more.js
+++ b/resources/assets/js/read-more.js
@@ -2,9 +2,14 @@ const ReadOnly = ({ value }) => ({
     value,
     showMore: false,
     showExpand: false,
+    init() {
+        this.$nextTick(() => {
+            this.truncate()
+        })
+    },
     truncate() {
-        const el = this.$el.querySelector(".read-more-content");
-        const expand = this.$el.querySelector(".read-more-expand");
+        const el = this.$root.querySelector(".read-more-content");
+        const expand = this.$root.querySelector(".read-more-expand");
 
         expand.style.display = "none";
         el.innerHTML = "";
@@ -28,7 +33,7 @@ const ReadOnly = ({ value }) => ({
         } while (length > 1 && this.hasOverflow(el));
     },
     showAll() {
-        const el = this.$el.querySelector(".read-more-content");
+        const el = this.$root.querySelector(".read-more-content");
 
         el.innerHTML = "";
         el.appendChild(document.createTextNode(this.value));

--- a/resources/assets/js/read-more.js
+++ b/resources/assets/js/read-more.js
@@ -28,7 +28,7 @@ const ReadOnly = ({ value }) => ({
 
                 this.showExpand = true;
             } while (length > 1 && this.hasOverflow(el));
-        })
+        });
     },
     showAll() {
         const el = this.$root.querySelector(".read-more-content");

--- a/resources/views/read-more.blade.php
+++ b/resources/views/read-more.blade.php
@@ -1,9 +1,9 @@
 <div class="read-more-container">
     <div
-        x-data="ReadMore({ value: '{{ $content }}'})"
+        x-data="ReadMore({ value: {{ json_encode($content) }}, })"
         :class="{ 'flex': ! showMore }"
         x-init="truncate"
-        x-on:resize.window="hideOptionAndTruncate"
+        x-on:resize.window="$nextTick(() => this.truncate())"
         x-cloak
     >
         <div

--- a/resources/views/read-more.blade.php
+++ b/resources/views/read-more.blade.php
@@ -2,8 +2,7 @@
     <div
         x-data="ReadMore({ value: {{ json_encode($content) }}, })"
         :class="{ 'flex': ! showMore }"
-        x-init="truncate"
-        x-on:resize.window="$nextTick(() => truncate())"
+        x-on:resize.window="truncate()"
         x-cloak
     >
         <div

--- a/resources/views/read-more.blade.php
+++ b/resources/views/read-more.blade.php
@@ -3,7 +3,7 @@
         x-data="ReadMore({ value: {{ json_encode($content) }}, })"
         :class="{ 'flex': ! showMore }"
         x-init="truncate"
-        x-on:resize.window="$nextTick(() => this.truncate())"
+        x-on:resize.window="$nextTick(() => truncate())"
         x-cloak
     >
         <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/29b9vta

For one, `$el` in Alpine v3 no longer retrieves the root element, but the current element. Second, we need to truncate on init, but only on next tick once elements are in the DOM. Same thing with resizing, on resize we want to wait a tick for all elements to update, and only then **truncate** and not **truncate and hide option**.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
