### PR TITLE
refactor: add the ability to pass `autoHeight` option to slider

### DIFF
--- a/resources/views/includes/slider/scripts.blade.php
+++ b/resources/views/includes/slider/scripts.blade.php
@@ -9,6 +9,7 @@
                 slidesPerView: 1,
                 slidesPerGroup: 1,
                 slidesPerColumn: 1,
+                autoHeight: {{ json_encode($autoHeight) }},
                 spaceBetween: {{ $spaceBetween }},
                 breakpoints: {!! json_encode($breakpoints) !!},
                 loop: {{ $loop ? 'true' : 'false' }},

--- a/resources/views/slider.blade.php
+++ b/resources/views/slider.blade.php
@@ -20,6 +20,7 @@
     'autoplayDelay'   => 3000,
     'hideViewAll'     => false,
     'shadowSpacing'   => false,
+    'autoHeight'      => false,
 ])
 
 @php


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Part of https://app.clickup.com/t/2aeeq5e

Adds the ability to not have all slides of equal height: https://swiperjs.com/swiper-api#param-autoHeight

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
