### PR TITLE
fix: set docs sidebar width to avoid shrinking

### DIFF
--- a/resources/views/pages/documentation.blade.php
+++ b/resources/views/pages/documentation.blade.php
@@ -18,7 +18,7 @@
         'py-8' => ! $compact,
     ])>
         <aside class="hidden flex-shrink-0 lg:block">
-            <div class="overflow-y-auto sticky top-32 pr-10 h-sidebar custom-scroll w-72">
+            <div class="overflow-y-auto sticky top-32 pr-10 w-72 h-sidebar custom-scroll">
                 @if($document->category)
                     <div class="pb-6 pl-6">
                         @unless ($isTutorial)

--- a/resources/views/pages/documentation.blade.php
+++ b/resources/views/pages/documentation.blade.php
@@ -18,7 +18,7 @@
         'py-8' => ! $compact,
     ])>
         <aside class="hidden flex-shrink-0 lg:block">
-            <div class="overflow-y-auto sticky top-32 pr-10 h-sidebar custom-scroll">
+            <div class="overflow-y-auto sticky top-32 pr-10 h-sidebar custom-scroll w-72">
                 @if($document->category)
                     <div class="pb-6 pl-6">
                         @unless ($isTutorial)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

part of https://app.clickup.com/t/2c24em0

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
