### PR TITLE
fix: allow html notifications in overview

### DIFF
--- a/resources/views/components/manage-notifications.blade.php
+++ b/resources/views/components/manage-notifications.blade.php
@@ -199,7 +199,11 @@
                                     </div>
                                     <div class="text-base leading-7 text-theme-secondary-700 dark:text-theme-secondary-500">
                                         <div class="flex flex-col sm:block">
-                                            <span class="break-words">{{ $notification->excerpt() }}</span>
+                                            @if( $renderAsHtml )
+                                                <span class="break-words">{!! $notification->content() !!}</span>
+                                            @else
+                                                <span class="break-words">{{ $notification->excerpt() }}</span>
+                                            @endif
 
                                             @if($notification->hasAction())
                                                 <a href="{{ $notification->link() }}" class="font-semibold link">

--- a/src/Hermes/Components/ManageNotifications.php
+++ b/src/Hermes/Components/ManageNotifications.php
@@ -25,6 +25,8 @@ final class ManageNotifications extends Component
 
     public string $activeFilter;
 
+    public bool $renderAsHtml;
+
     protected $listeners = [
         'setNotification'  => 'selectNotification',
         'markAsStarred',
@@ -33,8 +35,9 @@ final class ManageNotifications extends Component
         'markAsRead',
     ];
 
-    public function mount(): void
+    public function mount(bool $renderAsHtml = false): void
     {
+        $this->renderAsHtml = $renderAsHtml;
         $this->activeFilter = NotificationFilterEnum::ALL;
     }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This will allow for HTML notifications on the notifications page in addition to the navbar

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
