### PR TITLE
fix: re-add sidebar css regression

### DIFF
--- a/resources/assets/css/_components.css
+++ b/resources/assets/css/_components.css
@@ -516,3 +516,20 @@
 .notification-dot {
     @apply absolute block rounded-full;
 }
+
+/* Sidebar */
+.sidebar-group {
+    @apply px-8 lg:px-0 lg:ml-6;
+}
+
+.sidebar-link + .sidebar-group > button {
+    @apply border-t-0;
+}
+
+.sidebar-link {
+    @apply flex items-center;
+}
+
+.sidebar-link:last-child .sidebar-link-divider {
+    @apply hidden;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2expj1v

Fixes a regression to the sidebar link css in #356

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
