### PR TITLE
refactor: allow relatable notification icon

### DIFF
--- a/resources/views/notification-icon.blade.php
+++ b/resources/views/notification-icon.blade.php
@@ -1,11 +1,12 @@
 @props([
     'notification',
-    'type' => '',
+    'type'       => '',
+    'relatable'  => null,
     'stateColor' => 'bg-white dark:bg-theme-secondary-900',
 ])
 
 @php
-    $relatable = $notification->relatable;
+    $relatable = $relatable ?? $notification->relatable;
     $media = optional($relatable)->logo();
     $identifier = optional($relatable)->fallbackIdentifier();
     $defaultLogo =  $notification->logo();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2ecaefh

Allows overriding the relatable for notifications, so it can be passed in withTrashed

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
