### PR TITLE
fix: markdown editor's underline and embed modals

### DIFF
--- a/resources/assets/js/markdown-editor/markdown-editor.js
+++ b/resources/assets/js/markdown-editor/markdown-editor.js
@@ -221,6 +221,13 @@ const MarkdownEditor = (
             return `[${text || url}](${url})`;
         });
 
+        initModalhandler(this.editor, "embedLinkModal", (formData) => {
+            const url = formData.get("url");
+            const text = formData.get("text");
+
+            return `[${text || url}](${url})`;
+        });
+
         initModalhandler(this.editor, "embedTweetModal", (formData) => {
             const urlOrCode = formData.get("url");
 

--- a/resources/assets/js/markdown-editor/plugins/underline.js
+++ b/resources/assets/js/markdown-editor/plugins/underline.js
@@ -42,9 +42,7 @@ export default function underlinePlugin(name) {
                             )
                         );
 
-                    document
-                        .querySelector(`#markdown-editor-${name} .ProseMirror`)
-                        .focus();
+                    document.querySelector(".ProseMirror").focus();
 
                     dispatch(transaction);
 

--- a/resources/assets/js/markdown-editor/utils/utils.js
+++ b/resources/assets/js/markdown-editor/utils/utils.js
@@ -66,7 +66,7 @@ export const initModalhandler = (editor, modalName, getReplacement) => {
 
         const currentSelection = editor.getSelection();
 
-        editor.replaceSelection(replacement);
+        Alpine.raw(editor).replaceSelection(replacement);
 
         Livewire.emit("closeModal", modalName);
 
@@ -75,7 +75,7 @@ export const initModalhandler = (editor, modalName, getReplacement) => {
         setTimeout(() => {
             document.querySelector(".ProseMirror").focus();
 
-            editor.setSelection(
+            Alpine.raw(editor).setSelection(
                 [currentSelection[0][0], currentSelection[0][1]],
                 [
                     currentSelection[0][0],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2ff3c10 & https://app.clickup.com/t/2ff34z6

- Underline is fixed by targeting proper editor element to focus
- Embed modals is fixed by wrapping the MDEditor property into `Alpine.raw()` as this was some weird issue because Alpine properties are proxies
- Quick Link fix -- opening a link modal and clicking "Ok" would not add link due to missing handler

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
