### PR TITLE
fix: disable permission tool from registering in Nova v4

### DIFF
--- a/src/Providers/NovaServiceProvider.php
+++ b/src/Providers/NovaServiceProvider.php
@@ -103,9 +103,11 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     {
         self::resourcesIn(app_path('Nova'));
 
-        Nova::resources([
-            NovaPermission::class,
-            NovaRole::class,
-        ]);
+        if (! str_starts_with(Nova::version(), '4.')) {
+            Nova::resources([
+                NovaPermission::class,
+                NovaRole::class,
+            ]);
+        }
     }
 }

--- a/src/Providers/NovaServiceProvider.php
+++ b/src/Providers/NovaServiceProvider.php
@@ -103,6 +103,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     {
         self::resourcesIn(app_path('Nova'));
 
+        // TODO: enable when https://github.com/vyuldashev/nova-permission merges in support for Nova v4...
         if (! str_starts_with(Nova::version(), '4.')) {
             Nova::resources([
                 NovaPermission::class,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

It seems that the library we use for managing permissions (https://github.com/vyuldashev/nova-permission) hasn't been updated to support Nova v4. So we can use Nova v4 in other projects, this PR temporarily disables these tools from registering within Nova.

I'd personally go for building in-house tool for this, but we can do that later on when we need to CRUD permissions and roles.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
