### PR TITLE
refactor: do not escape meta title

### DIFF
--- a/resources/views/pages/includes/layout-head.blade.php
+++ b/resources/views/pages/includes/layout-head.blade.php
@@ -12,7 +12,7 @@
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    <title>{{ trim(View::yieldContent('title', $defaultName)) }}</title>
+    <title>{!! trim(View::yieldContent('title', $defaultName)) !!}</title>
 
     @if (config('ui.dark-mode.enabled') === true)
         <x-ark-dark-theme-script />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Meta titles can have chars like `&` that are not parsed on the title that the users see on browser, this PR ensures we do not escape titles like we do [with the rest of the metadata](https://github.com/ArkEcosystem/laravel-foundation/blob/main/resources/views/metadata-tags.blade.php)

Related to https://app.clickup.com/t/2hdq5gc

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
