### PR TITLE
refactor: use databag for 2fa pages

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -14,7 +14,7 @@
 @endsection
 
 @section('content')
-    <x:ark-fortify::component-heading :title="trans('ui::auth.two-factor.page_header')" :description="trans('ui::auth.two-factor.page_description')" />
+    <x-data-bag key="fortify-content" resolver="name" view="ark-fortify::components.component-heading"/>
 
     <div x-data="{ recovery: @json($errors->has('recovery_code')) }" x-cloak>
         @include('ark-fortify::auth.two-factor.form')

--- a/resources/views/components/component-heading.blade.php
+++ b/resources/views/components/component-heading.blade.php
@@ -1,6 +1,9 @@
 <div class="py-8 w-full dark:bg-black bg-theme-secondary-100">
     <div class="container mx-auto">
-        <h1 class="mx-4 text-center md:mx-8 xl:mx-16 dark:text-theme-secondary-200">{{ $title }}</h1>
-        <p class="mx-8 mt-4 text-lg font-semibold leading-8 text-center md:mx-8 xl:mx-16 text-theme-secondary-700 dark:text-theme-secondary-500">{{ $description }}</p>
+        <h1 class="mx-4 text-center md:mx-8 xl:mx-16 dark:text-theme-secondary-200">{{ $title ?? $pageTitle }}</h1>
+
+        @isset ($description)
+            <p class="mx-8 mt-4 text-lg font-semibold leading-8 text-center md:mx-8 xl:mx-16 text-theme-secondary-700 dark:text-theme-secondary-500">{{ $description }}</p>
+        @endisset
     </div>
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

needed for https://app.clickup.com/t/2hcxxvc

This PR uses the databag for 2FA verification page. That approach allows us to override the `component-heading` with our own component, just like we did to add colorful banner. Since now we use databag, we can't just rely on the fact that all other products have databag variables to 2FA pages implemented, so I just added a quick check for variables for pages to not fail when loaded.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
