### PR TITLE
refactor: accept custom scripts on confirm modal and on init method

### DIFF
--- a/resources/assets/js/modal.js
+++ b/resources/assets/js/modal.js
@@ -109,6 +109,7 @@ const Modal = {
             options: null,
             init() {
                 const scrollable = this.getScrollable();
+
                 if (this.name) {
                     Livewire.on("openModal", (modalName, ...options) => {
                         if (this.name === modalName) {
@@ -151,6 +152,10 @@ const Modal = {
 
                 if (this.shown) {
                     Modal.onModalOpened(scrollable, eventSettings);
+                }
+
+                if (typeof this.onInit === "function") {
+                    this.onInit();
                 }
             },
             hide() {

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -1,7 +1,6 @@
 @props([
     'selector' => null,
 ])
-
 {{-- External link svg uses the below classes so needs adding here so purge keeps them --}}
 {{-- inline ml-1 -mt-1.5 --}}
 <x-ark-js-modal
@@ -30,6 +29,7 @@
 
             this.hide();
         },
+        ...ExternalLinkConfirm || {}
     }"
     disable-outside-click
     hide-cross

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -29,7 +29,7 @@
 
             this.hide();
         },
-        ...ExternalLinkConfirm || {}
+        ...(typeof ExternalLinkConfirm !== 'undefined' ? ExternalLinkConfirm : {})
     }"
     disable-outside-click
     hide-cross


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds a way to inject custom scripts to the confirmation modal (used to add history handling for this ticket https://app.clickup.com/t/2hxy2vm)

And a new method in the modal used for the same purpose.

Dependant of https://github.com/ArdentHQ/msq.io/pull/196
## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [X] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [x] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
