### PR TITLE
feat: dark mode modal overlay color for external links

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -68,7 +68,7 @@
             class="fixed top-0 right-0 z-20"
         />
 
-        <div class="flex fixed inset-0 flex-col w-screen h-screen bg-white bg-opacity-90 backdrop-filter backdrop-blur-xl"></div>
+        <div class="flex fixed inset-0 flex-col w-screen h-screen bg-white bg-opacity-90 backdrop-filter backdrop-blur-xl dark:bg-black dark:bg-opacity-95"></div>
     </x-slot>
 
     <x-slot name="buttons">

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -68,7 +68,7 @@
             class="fixed top-0 right-0 z-20"
         />
 
-        <div class="flex fixed inset-0 flex-col w-screen h-screen bg-white bg-opacity-90 backdrop-filter backdrop-blur-xl dark:bg-black dark:bg-opacity-95"></div>
+        <div class="flex fixed inset-0 flex-col w-screen h-screen bg-white bg-opacity-90 dark:bg-black dark:bg-opacity-95 backdrop-filter backdrop-blur-xl"></div>
     </x-slot>
 
     <x-slot name="buttons">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the color of the overlay for dark mode in the external link modal

Dependant of https://github.com/ArdentHQ/msq.io/pull/256

![image](https://user-images.githubusercontent.com/17262776/179577094-0287fb96-0d8d-4c28-ace9-d67b5493c646.png)

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
