### PR TITLE
feat: markdown syntax for adding image with markdown captions

### DIFF
--- a/resources/assets/css/_document.css
+++ b/resources/assets/css/_document.css
@@ -205,6 +205,10 @@ code.hljs .hljs-ln-n {
     @apply relative block mx-auto text-theme-secondary-800 dark:text-theme-secondary-200 border-l-2 border-theme-secondary-300 text-sm px-3 mt-3 italic text-center dark:border-theme-secondary-800;
 }
 
+.documentation-content .image-caption .external-link svg {
+    @apply w-3 h-3 -mt-1;
+}
+
 /* Misc */
 .documentation-content .embed-link a:hover {
     @apply no-underline;

--- a/src/CommonMark/Extensions/Node/Block/ImageWithRichCaption.php
+++ b/src/CommonMark/Extensions/Node/Block/ImageWithRichCaption.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\CommonMark\Extensions\Node\Block;
+
+use League\CommonMark\Node\Block\AbstractBlock;
+use League\CommonMark\Node\RawMarkupContainerInterface;
+
+class ImageWithRichCaption extends AbstractBlock implements RawMarkupContainerInterface
+{
+    private string $literal = '';
+
+    public function getLiteral(): string
+    {
+        return $this->literal;
+    }
+
+    public function setLiteral(string $literal): void
+    {
+        $this->literal = $literal;
+    }
+}

--- a/src/CommonMark/Extensions/Parser/Block/ImageWithRichCaptionParser.php
+++ b/src/CommonMark/Extensions/Parser/Block/ImageWithRichCaptionParser.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\CommonMark\Extensions\Parser\Block;
+
+use ARKEcosystem\Foundation\CommonMark\Extensions\Node\Block\ImageWithRichCaption;
+use Illuminate\Support\Arr;
+use League\CommonMark\Parser\Block\AbstractBlockContinueParser;
+use League\CommonMark\Parser\Block\BlockContinue;
+use League\CommonMark\Parser\Block\BlockContinueParserInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\InlineParserEngineInterface;
+use League\CommonMark\Parser\Block\BlockContinueParserWithInlinesInterface;
+
+final class ImageWithRichCaptionParser extends AbstractBlockContinueParser implements BlockContinueParserWithInlinesInterface
+{
+    /** @psalm-readonly */
+    private ImageWithRichCaption $block;
+
+    private string $content = '';
+
+    private bool $finished = false;
+
+    public function __construct()
+    {
+        $this->block = new ImageWithRichCaption();
+    }
+
+    public function getBlock(): ImageWithRichCaption
+    {
+        return $this->block;
+    }
+
+    public function tryContinue(Cursor $cursor, BlockContinueParserInterface $activeBlockParser): ?BlockContinue
+    {
+        if ($this->finished) {
+            return BlockContinue::finished();
+        }
+
+        return BlockContinue::at($cursor);
+    }
+
+
+
+    public function addLine(string $line): void
+    {
+        if ($this->content !== '') {
+            $this->content .= "\n";
+        }
+
+        $this->content .= $line;
+
+        if (\preg_match('/\[\/img\]/', $line) === 1) {
+            $this->finished = true;
+        }
+    }
+
+    public function parseInlines(InlineParserEngineInterface $inlineParser): void
+    {
+        $data = $this->getSrcAndContent();
+
+        $content = sprintf('![](%s)<span class="rich-image-caption image-caption">%s</span>', $data['src'], $data['content']);
+
+        $inlineParser->parse($content . "\n\n", $this->block);
+    }
+
+    private function getSrcAndContent(): array
+    {
+        $regex = '/\[img.*src=["“\'](?<src>[^"”\']*)["”\'][^]]*](?<content>[\S\s]*)(?=\[\/img])/m';
+
+        preg_match($regex, $this->content, $matches);
+
+        return [
+            'src' => Arr::get($matches, 'src'),
+            'content' => Arr::get($matches, 'content'),
+        ];
+    }
+}

--- a/src/CommonMark/Extensions/Parser/Block/ImageWithRichCaptionStartParser.php
+++ b/src/CommonMark/Extensions/Parser/Block/ImageWithRichCaptionStartParser.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\CommonMark\Extensions\Parser\Block;
+
+use League\CommonMark\Parser\Block\BlockStart;
+use League\CommonMark\Parser\Block\BlockStartParserInterface;
+use League\CommonMark\Parser\Cursor;
+use League\CommonMark\Parser\MarkdownParserStateInterface;
+use League\CommonMark\Util\RegexHelper;
+
+final class ImageWithRichCaptionStartParser implements BlockStartParserInterface
+{
+    public function tryStart(Cursor $cursor, MarkdownParserStateInterface $parserState): ?BlockStart
+    {
+        if ($cursor->isIndented() || $cursor->getNextNonSpaceCharacter() !== '[') {
+            return BlockStart::none();
+        }
+
+        $tmpCursor = clone $cursor;
+        $tmpCursor->advanceToNextNonSpaceOrTab();
+        $line = $tmpCursor->getRemainder();
+
+        $match = RegexHelper::matchAt(
+            '/\[img.*src=["“\'](?<src>[^"”\']*)["”\'][^]]*]/',
+            $line
+        );
+
+        if ($match !== null) {
+            return BlockStart::of(new ImageWithRichCaptionParser())->at($cursor);
+        }
+
+        return BlockStart::none();
+    }
+}

--- a/src/CommonMark/Extensions/Renderer/Block/ImageWithRichCaptionRenderer.php
+++ b/src/CommonMark/Extensions/Renderer/Block/ImageWithRichCaptionRenderer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\CommonMark\Extensions\Renderer\Block;
+
+use ARKEcosystem\Foundation\CommonMark\Extensions\Node\Block\ImageWithRichCaption;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use League\CommonMark\Xml\XmlNodeRendererInterface;
+
+final class ImageWithRichCaptionRenderer implements NodeRendererInterface, XmlNodeRendererInterface
+{
+    /**
+     * @param ImageWithRichCaption $node
+     *
+     * {@inheritDoc}
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
+     */
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): \Stringable
+    {
+        ImageWithRichCaption::assertInstanceOf($node);
+
+        $innerSeparator = $childRenderer->getBlockSeparator();
+
+        return new HtmlElement('div',
+            [
+                'class' => 'image-container',
+            ],
+            $innerSeparator . $childRenderer->renderNodes($node->children()) . $innerSeparator
+        );
+    }
+
+
+    public function getXmlTagName(Node $node): string
+    {
+        return 'image_with_richcaption';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getXmlAttributes(Node $node): array
+    {
+        return [];
+    }
+}

--- a/src/CommonMark/Extensions/Renderer/Block/ImageWithRichCaptionRenderer.php
+++ b/src/CommonMark/Extensions/Renderer/Block/ImageWithRichCaptionRenderer.php
@@ -26,11 +26,14 @@ final class ImageWithRichCaptionRenderer implements NodeRendererInterface, XmlNo
 
         $innerSeparator = $childRenderer->getBlockSeparator();
 
-        return new HtmlElement('div',
-            [
-                'class' => 'image-container',
-            ],
-            $innerSeparator . $childRenderer->renderNodes($node->children()) . $innerSeparator
+        return new HtmlElement('p',
+            [],
+            new HtmlElement('div',
+                [
+                    'class' => 'image-container',
+                ],
+                $innerSeparator . $childRenderer->renderNodes($node->children()) . $innerSeparator
+            )
         );
     }
 

--- a/src/Providers/CommonMarkServiceProvider.php
+++ b/src/Providers/CommonMarkServiceProvider.php
@@ -10,7 +10,13 @@ use ARKEcosystem\Foundation\CommonMark\Extensions\Highlighter\FencedCodeRenderer
 use ARKEcosystem\Foundation\CommonMark\Extensions\Highlighter\IndentedCodeRenderer;
 use ARKEcosystem\Foundation\CommonMark\Extensions\Image\ImageRenderer;
 use ARKEcosystem\Foundation\CommonMark\Extensions\Link\LinkRenderer;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Node\Block\ImageWithRichCaption;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Node\Block\RichCaption;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Parser\Block\ImageWithRichCaptionStartParser;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Parser\Block\RichCaptionStartParser;
 use ARKEcosystem\Foundation\CommonMark\Extensions\Parser\Inline\SVGParser;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Renderer\Block\ImageWithRichCaptionRenderer;
+use ARKEcosystem\Foundation\CommonMark\Extensions\Renderer\Block\RichCaptionRenderer;
 use ARKEcosystem\Foundation\CommonMark\View\BladeEngine;
 use ARKEcosystem\Foundation\CommonMark\View\BladeMarkdownEngine;
 use ARKEcosystem\Foundation\CommonMark\View\FileViewFinder;
@@ -153,6 +159,8 @@ final class CommonMarkServiceProvider extends ServiceProvider
         $environment->addBlockStartParser(new HtmlBlockStartParser(), 40);
         $environment->addBlockStartParser(new HeadingStartParser(), 30);
         $environment->addBlockStartParser(new ThematicBreakStartParser(), 20);
+        $environment->addBlockStartParser(new ImageWithRichCaptionStartParser(), 20);
+
         // $environment->addBlockStartParser(new ListParser(), 10);
         $environment->addBlockStartParser(new IndentedCodeStartParser(), -100);
         // $environment->addBlockStartParser(new ParagraphParser(), -200);
@@ -186,6 +194,7 @@ final class CommonMarkServiceProvider extends ServiceProvider
         $environment->addRenderer(Newline::class, new NewlineRenderer(), 0);
         $environment->addRenderer(Strong::class, new StrongRenderer(), 0);
         $environment->addRenderer(Text::class, new TextRenderer(), 0);
+        $environment->addRenderer(ImageWithRichCaption::class, new ImageWithRichCaptionRenderer(), 0);
 
         $inlineRenderers = array_merge([
             Code::class       => CodeRenderer::class,

--- a/usage/commonmark.md
+++ b/usage/commonmark.md
@@ -10,6 +10,14 @@
 
 This package provides parsing and rendering for CommonMark. All the specifications and examples can be seen at https://commonmark.org/. There are a few custom elements that can be used to embed third-party content.
 
+### Add an image with a caption that accepts markdown
+
+```markdown
+[img src="https://i.imgur.com/tpEev9m.png"]
+Caption with **markdown** 
+[/img]
+```
+
 ### Embed SimpleCast
 
 ```markdown


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

To test:

Use the new syntax to add images with markdown.

Note: Since this is intended to add simple stuff like links or bold text I think we don't need to make a deep test with all the possible markdown combinations we can use * Inserts !samdisclaimer *

```markdown
[img src="https://i.imgur.com/tpEev9m.png"]
Caption with **markdown** 
[/img]
```

Note: in msq we are overriding the caption design; by default, a caption with a link is going to look like this:
![image](https://user-images.githubusercontent.com/17262776/179818299-eb982094-b4dd-421d-a506-730e6dd11cf2.png)


On dependant msq PR it looks like this:
![image](https://user-images.githubusercontent.com/17262776/179818520-da7d818d-451f-4faa-a03d-aec9170a9bd0.png)

 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I provided a screenshot of my changes to the component _(if applicable)_
-   [X] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
