### PR TITLE
fix(docs): sidebar link indentations + ability to add top border to a sidebar link

### DIFF
--- a/resources/views/docs/sidebar-group.blade.php
+++ b/resources/views/docs/sidebar-group.blade.php
@@ -14,7 +14,7 @@
     <button
         type="button"
         @class([
-            'flex items-center justify-between mx-5 lg:mx-0 lg:pr-5 py-4 border-theme-secondary-300 group',
+            'flex items-center justify-between lg:pr-5 py-4 border-theme-secondary-300 group',
             'border-t' => ! $borderless,
         ])
         @click.prevent="open = ! open"

--- a/resources/views/docs/sidebar-link.blade.php
+++ b/resources/views/docs/sidebar-link.blade.php
@@ -59,7 +59,7 @@
     </div>
 @else
     @if (count($children) === 0)
-        <div class="relative pr-0 ml-5 -mr-5 border-l lg:mx-0 sidebar-link border-theme-secondary-300">
+        <div class="relative pr-0 -mr-5 border-l lg:mx-0 sidebar-link border-theme-secondary-300">
             <div @class([
                 'absolute h-full -left-2.5px z-10 border-l-4 rounded-lg',
                 'border-theme-primary-600' => $onDocs,

--- a/resources/views/docs/sidebar-link.blade.php
+++ b/resources/views/docs/sidebar-link.blade.php
@@ -3,6 +3,7 @@
     'name',
     'children' => [],
     'topLevel' => false,
+    'topBorder' => true,
     'first' => false,
     'borderless' => false,
 ])
@@ -17,6 +18,17 @@
         ])></div>
 
         <div class="w-full lg:h-auto h-13">
+            @if ($topBorder)
+                <div class="flex">
+                    <x-ark-divider
+                        :class="Arr::toCssClasses([
+                            'mx-8 lg:ml-5 lg:mr-0',
+                            'hidden lg:block' => $onDocs,
+                        ])"
+                    />
+                </div>
+            @endif
+
             <div @class([
                 'lg:rounded-r w-full pl-8 lg:pl-6',
                 'text-theme-primary-600 bg-theme-primary-100 lg:my-1' => $onDocs,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds the ability to add top-border to solve: https://app.clickup.com/t/2hyzd6y

Also solves https://app.clickup.com/t/2mkrrmh & https://app.clickup.com/t/2mkrrra


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
