### PR TITLE
refactor: external link modal dark text color

### DIFF
--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -48,7 +48,7 @@
                 </x-ark-alert>
             </div>
 
-            <p class="dark:text-theme-secondary-500 text-theme-secondary-700">@lang('ui::general.external_link_disclaimer')</p>
+            <p class="text-theme-secondary-700 dark:text-theme-secondary-500">@lang('ui::general.external_link_disclaimer')</p>
 
             <x-ark-checkbox
                 name="confirmation"

--- a/resources/views/external-link-confirm.blade.php
+++ b/resources/views/external-link-confirm.blade.php
@@ -48,12 +48,12 @@
                 </x-ark-alert>
             </div>
 
-            <p>@lang('ui::general.external_link_disclaimer')</p>
+            <p class="dark:text-theme-secondary-500 text-theme-secondary-700">@lang('ui::general.external_link_disclaimer')</p>
 
             <x-ark-checkbox
                 name="confirmation"
                 alpine="toggle"
-                label-classes="text-theme-secondary-700 select-none font-semibold"
+                label-classes="text-theme-secondary-700 dark:text-theme-secondary-500 select-none font-semibold"
             >
                 @slot('label')
                     @lang('ui::forms.do_not_show_message_again')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Updates the default text color for dark mode

![image](https://user-images.githubusercontent.com/17262776/181071309-3c60a8df-669c-44d2-9fdf-398d7154ac59.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
