### PR TITLE
fix: do not cache response for Fortify's authentication pages

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Laravel\Fortify\Features;
+use Spatie\ResponseCache\Middlewares\DoNotCacheResponse;
 
 return [
 
@@ -88,7 +89,7 @@ return [
     |
     */
 
-    'middleware' => ['web'],
+    'middleware' => ['web', DoNotCacheResponse::class],
 
     'middlewares' => [
         'account_settings' => [


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2jfwnbm

Turns out, if response cache is enabled, authentication pages don't show any validation errors. To test, add the 
`DoNotCacheResponse::class` middleware to `middleware` in fortify config file, just like in this PR. Foundation already imports `spatie/laravel-responsecache` so we can reference that class in foundation itself.

Since other projects have their `fortify.php` config file exported, this will need to be updated in all of them so keep an eye on PRs for those projects.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
