### PR TITLE
fix: center "edit page" on mobile for documentation pages

### DIFF
--- a/resources/views/docs/edit-page.blade.php
+++ b/resources/views/docs/edit-page.blade.php
@@ -6,11 +6,11 @@
     href="{{ config('web.github_source') }}/tree/master/{{ $document->type }}/{{ $document->slug }}.md.blade.php"
     target="_blank"
     rel="noopener nofollow noreferrer"
-    class="flex items-center pl-5 space-x-3 font-semibold link"
+    class="flex items-center sm:pl-5 space-x-3 font-semibold link"
 >
-    <x-ark-icon 
-        name="pencil" 
-        size="sm" 
+    <x-ark-icon
+        name="pencil"
+        size="sm"
     />
 
     <span>@lang('ui::actions.docs.edit_page')</span>

--- a/resources/views/docs/edit-page.blade.php
+++ b/resources/views/docs/edit-page.blade.php
@@ -6,7 +6,7 @@
     href="{{ config('web.github_source') }}/tree/master/{{ $document->type }}/{{ $document->slug }}.md.blade.php"
     target="_blank"
     rel="noopener nofollow noreferrer"
-    class="flex items-center sm:pl-5 space-x-3 font-semibold link"
+    class="flex items-center space-x-3 font-semibold sm:pl-5 link"
 >
     <x-ark-icon
         name="pencil"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
