### PR TITLE
fix: allow extended footer color overrides

### DIFF
--- a/resources/views/extended-footer.blade.php
+++ b/resources/views/extended-footer.blade.php
@@ -1,4 +1,8 @@
-<section {{ $attributes->class('bg-theme-secondary-900') }}>
+@props ([
+    'backgroundColor' => 'bg-theme-secondary-900',
+])
+
+<section {{ $attributes->class($backgroundColor) }}>
     <div class="flex flex-col py-12 px-8 mx-auto md:px-10 lg:flex-row lg:space-y-0 lg:space-x-6 lg:max-w-7xl lg:divide-x divide-theme-secondary-800">
         <div class="flex-1">
             <div class="space-y-4">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Allow overriding extended footer background, for https://github.com/ArkEcosystem/arkscic.com/pull/56

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
