### PR TITLE
refactor: standardize translations in Blade files

### DIFF
--- a/resources/views/alert.blade.php
+++ b/resources/views/alert.blade.php
@@ -36,7 +36,7 @@
                 <button
                     type="button"
                     @click="show = false"
-                    aria-label="{{ trans('ui::alert.dismiss') }}"
+                    aria-label="@lang ('ui::alert.dismiss')"
                 >
                     <x-ark-icon name="cross" size="xs" aria-hidden="true" focusable="false" />
                 </button>

--- a/resources/views/components/blog/article-content.blade.php
+++ b/resources/views/components/blog/article-content.blade.php
@@ -27,7 +27,7 @@
                 </div>
 
                 <div>
-                    {{ formatReadTime($article->reading_time) }} {{ trans('ui::pages.blog.read') }}
+                    {{ formatReadTime($article->reading_time) }} @lang ('ui::pages.blog.read')
                 </div>
             </div>
 

--- a/resources/views/components/blog/related-articles.blade.php
+++ b/resources/views/components/blog/related-articles.blade.php
@@ -6,7 +6,7 @@
 
 <section>
     <div class="flex justify-between items-center">
-        <h3 class="header-2">{{ trans('ui::pages.blog.related', ['category' => $article->category->value]) }}</h3>
+        <h3 class="header-2">@lang ('ui::pages.blog.related', ['category' => $article->category->value])</h3>
 
         @if ($hasAdditional)
             <a href="{{ route('blog', ['category' => $article->category->value]) }}" class="flex items-center space-x-2 font-semibold link">

--- a/resources/views/inputs/markdown.blade.php
+++ b/resources/views/inputs/markdown.blade.php
@@ -57,18 +57,18 @@
                 @if($showCharsCount || $showWordsCount || $showReadingTime)
                     <div x-cloak class="flex justify-end py-3 text-xs bg-white border-t border-theme-secondary-200 dark:border-theme-secondary-700 dark:bg-theme-secondary-900 dark:text-theme-secondary-500">
                         @if($showWordsCount)
-                            <span class="px-4">{{ trans('ui::forms.wysiwyg.words') }}: <strong x-text="wordsCount" x-bind:class="{ 'opacity-75': loadingCharsCount }"></strong></span>
+                            <span class="px-4">@lang ('ui::forms.wysiwyg.words'): <strong x-text="wordsCount" x-bind:class="{ 'opacity-75': loadingCharsCount }"></strong></span>
                         @endif
                         @if($showCharsCount)
                             <span class="px-4 border-l-2 border-theme-secondary-200 dark:border-theme-secondary-700">
-                                {{ trans('ui::forms.wysiwyg.characters') }}:
+                                @lang ('ui::forms.wysiwyg.characters'):
                                 <strong x-text="charsCount" :class="{ 'text-theme-danger-500': charsLimit < charsCount, 'opacity-75': loadingCharsCount }"></strong>
                                 <span x-bind:class="{ 'inline': charsLimit, 'hidden': !charsLimit }">/</span>
                                 <strong x-text="charsLimit" :class="{ 'inline': charsLimit, 'hidden': !charsLimit, 'text-theme-danger-500': charsLimit < charsCount, 'opacity-75': loadingCharsCount }"></strong>
                             </span>
                         @endif
                         @if($showReadingTime)
-                            <span class="px-4 border-l-2 border-theme-secondary-200 dark:border-theme-secondary-700">{{ trans('ui::forms.wysiwyg.reading_time') }}: <strong><span x-text="readMinutes" x-bind:class="{ 'opacity-75': loadingCharsCount }"></span> {{ trans('ui::forms.wysiwyg.min') }}</strong></span>
+                            <span class="px-4 border-l-2 border-theme-secondary-200 dark:border-theme-secondary-700">@lang ('ui::forms.wysiwyg.reading_time'): <strong><span x-text="readMinutes" x-bind:class="{ 'opacity-75': loadingCharsCount }"></span> @lang ('ui::forms.wysiwyg.min')</strong></span>
                         @endif
                     </div>
                 @endif

--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -60,7 +60,7 @@
     <div class="{{ $heightClass ?? 'h-21'}}"></div>
 
     <nav
-        aria-label="{{ trans('ui::general.primary_navigation') }}"
+        aria-label="@lang ('ui::general.primary_navigation')"
         x-ref="nav"
         @class([
             'fixed top-0 z-30 w-full dark:bg-theme-secondary-900 dark:border-theme-secondary-800 transition duration-400',

--- a/resources/views/pagination-url.blade.php
+++ b/resources/views/pagination-url.blade.php
@@ -13,7 +13,7 @@
                 min="1"
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
-                placeholder="{{ trans('ui::actions.enter_the_page') }}"
+                placeholder="@lang ('ui::actions.enter_the_page')"
                 class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
@@ -87,7 +87,7 @@
                     min="1"
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
-                    placeholder="{{ trans('ui::actions.enter_the_page_number') }}"
+                    placeholder="@lang ('ui::actions.enter_the_page_number')"
                     class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />

--- a/resources/views/pagination.blade.php
+++ b/resources/views/pagination.blade.php
@@ -13,7 +13,7 @@
                 min="1"
                 max="{{ $paginator->lastPage() }}"
                 name="{{ $pageName }}"
-                placeholder="{{ trans('ui::actions.enter_the_page') }}"
+                placeholder="@lang ('ui::actions.enter_the_page')"
                 class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                 x-on:blur="blurHandler"
             />
@@ -71,7 +71,7 @@
                     min="1"
                     max="{{ $paginator->lastPage() }}"
                     name="{{ $pageName }}"
-                    placeholder="{{ trans('ui::actions.enter_the_page_number') }}"
+                    placeholder="@lang ('ui::actions.enter_the_page_number')"
                     class="py-2 px-3 w-full bg-transparent dark:text-theme-secondary-200"
                     x-on:blur="blurHandler"
                 />

--- a/resources/views/profile/delete-user-form.blade.php
+++ b/resources/views/profile/delete-user-form.blade.php
@@ -52,7 +52,7 @@
                 </div>
                 @elseif($confirmName)
                 <div class="flex flex-col mt-4">
-                    <span class="input-label">{{ trans('modals.delete-user.title') }}</span>
+                    <span class="input-label">@lang ('modals.delete-user.title')</span>
                     <div class="mb-2 input-wrapper">
                         <input type="text" value="{{ $this->user->name }}" class="font-semibold text-center input-text" readonly/>
                     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1mjqkr9

While I still believe `{{ trans() }}` is a better choice due to consistency because we're forced to use `trans` in other places (component props, e.g. `<x-ark-component :prop="trans('something')" />`), most of the Blade files use `@lang` so it makes sense to change it to be consistent.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
