### PR TITLE
fix: change `min-w-max-content` to `min-w-max` for rich select component

### DIFF
--- a/resources/views/inputs/rich-select.blade.php
+++ b/resources/views/inputs/rich-select.blade.php
@@ -13,7 +13,7 @@
     'label' => null,
     'xData' => '{}',
     'height' => '320',
-    'width' => 'w-full min-w-max-content',
+    'width' => 'w-full min-w-max',
 ])
 
 @php


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Doesn't necessarily fix https://app.clickup.com/t/2uhduet, but it's the same issue.

https://tailwindcss.com/docs/min-width

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
