### PR TITLE
refactor: handle error codes outside templates

### DIFF
--- a/src/UserInterface/Exceptions/Concerns/OverridesExceptionView.php
+++ b/src/UserInterface/Exceptions/Concerns/OverridesExceptionView.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Foundation\UserInterface\Exceptions\Concerns;
+
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+trait OverridesExceptionView
+{
+    /**
+     * Get the view used to render HTTP exceptions.
+     *
+     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
+     * @return string|null
+     */
+    protected function getHttpExceptionView(HttpExceptionInterface $e)
+    {
+        $view = parent::getHttpExceptionView($e);
+        if ($view) {
+            return $view;
+        }
+
+        return 'errors::500';
+    }
+}

--- a/src/UserInterface/Exceptions/Handler.php
+++ b/src/UserInterface/Exceptions/Handler.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\View;
 
 class Handler extends ExceptionHandler
 {
-    use Concers\OverridesExceptionView;
+    use Concerns\OverridesExceptionView;
 
     /**
      * Register the error template hint paths.

--- a/src/UserInterface/Exceptions/Handler.php
+++ b/src/UserInterface/Exceptions/Handler.php
@@ -6,10 +6,11 @@ namespace ARKEcosystem\Foundation\UserInterface\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Support\Facades\View;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class Handler extends ExceptionHandler
 {
+    use Concers\OverridesExceptionView;
+
     /**
      * Register the error template hint paths.
      *
@@ -18,21 +19,5 @@ class Handler extends ExceptionHandler
     protected function registerErrorViewPaths()
     {
         View::replaceNamespace('errors', __DIR__.'/../../../resources/views/errors');
-    }
-
-    /**
-     * Get the view used to render HTTP exceptions.
-     *
-     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
-     * @return string|null
-     */
-    protected function getHttpExceptionView(HttpExceptionInterface $e)
-    {
-        $view = parent::getHttpExceptionView($e);
-        if ($view) {
-            return $view;
-        }
-
-        return 'errors::500';
     }
 }

--- a/src/UserInterface/Exceptions/Handler.php
+++ b/src/UserInterface/Exceptions/Handler.php
@@ -6,6 +6,7 @@ namespace ARKEcosystem\Foundation\UserInterface\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Support\Facades\View;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 
 class Handler extends ExceptionHandler
 {
@@ -17,5 +18,21 @@ class Handler extends ExceptionHandler
     protected function registerErrorViewPaths()
     {
         View::replaceNamespace('errors', __DIR__.'/../../../resources/views/errors');
+    }
+
+    /**
+     * Get the view used to render HTTP exceptions.
+     *
+     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
+     * @return string|null
+     */
+    protected function getHttpExceptionView(HttpExceptionInterface $e)
+    {
+        $view = parent::getHttpExceptionView($e);
+        if ($view) {
+            return $view;
+        }
+
+        return 'errors::500';
     }
 }

--- a/tests/Stubs/ExceptionHandler.php
+++ b/tests/Stubs/ExceptionHandler.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Stubs;
 
 use ARKEcosystem\Foundation\UserInterface\Exceptions\Concerns\OverridesExceptionView;
 use Orchestra\Testbench\Exceptions\Handler as Base;
-use Throwable;
 
 class ExceptionHandler extends Base
 {

--- a/tests/Stubs/ExceptionHandler.php
+++ b/tests/Stubs/ExceptionHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Stubs;
+
+use ARKEcosystem\Foundation\UserInterface\Exceptions\Concerns\OverridesExceptionView;
+use Orchestra\Testbench\Exceptions\Handler as Base;
+use Throwable;
+
+class ExceptionHandler extends Base
+{
+    use OverridesExceptionView;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,4 +62,9 @@ class TestCase extends Orchestra
             // CommonMarkServiceProvider::class, // TODO: custom finder from this causes component tests to fail
         ];
     }
+
+    protected function resolveApplicationExceptionHandler($app)
+    {
+        $app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', \Tests\Stubs\ExceptionHandler::class);
+    }
 }

--- a/tests/UserInterface/Exceptions/HandlerTest.php
+++ b/tests/UserInterface/Exceptions/HandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+it('should show 500 error page if template does not exist', function ($errorCode, $message): void {
+    Route::view('home', '')->name('home');
+    Route::get('error/{code}', function ($code) {
+        abort($code);
+    });
+
+    $response = $this->get("/error/${errorCode}")
+        ->assertSeeText($message);
+
+    $this->assertStringContainsString('<title>'.trans('ui::errors.500').' | Laravel</title>', $response->getContent());
+})->with([
+    [402, 'Oops, something went wrong'],
+    [408, 'Oops, something went wrong'],
+    [501, 'Oops, something went wrong'],
+    [519, 'Oops, something went wrong'],
+]);
+
+it('should show correct error page', function ($errorCode, $message): void {
+    Route::view('home', '')->name('home');
+    Route::get('error/{code}', function ($code) {
+        abort($code);
+    });
+
+    $response = $this->get("/error/${errorCode}")
+        ->assertSeeText($message);
+
+    $this->assertStringContainsString('<title>'.trans("ui::errors.${errorCode}").' | Laravel</title>', $response->getContent());
+})->with([
+    [401, 'Oops, something went wrong'],
+    [403, 'Oops, this is a restricted area!'],
+    [404, 'Oops, something went wrong'],
+    [419, 'Oops, something went wrong'],
+    [429, 'Oops, something went wrong'],
+    [500, 'Oops, something went wrong'],
+    [503, 'Laravel is currently down for scheduled maintenance.'],
+]);

--- a/tests/blade-views/layouts/app.blade.php
+++ b/tests/blade-views/layouts/app.blade.php
@@ -1,0 +1,8 @@
+<html>
+<head>
+    <title>@yield('title')</title>
+</head>
+<body>
+    @yield('content')
+</body>
+</html>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2ptfu0w

Used to show 500 error page if an error we don't handle is thrown

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
