### PR TITLE
fix: mobile navbar active state

### DIFF
--- a/resources/views/navbar.blade.php
+++ b/resources/views/navbar.blade.php
@@ -130,7 +130,7 @@
             @include('ark::navbar.items.mobile', [
                 'mobilePositionClass' => $mobilePositionClass ?? null,
                 'mobileDropdownItemColor' => 'text-theme-secondary-900 hover:text-theme-secondary-900 dark:text-theme-secondary-200 dark:hover:text-theme-secondary-200',
-                'mobileDropdownActiveItemColor' => 'dark:bg-theme-secondary-800 dark:text-theme-secondary-200 text-theme-secondary-900 bg-theme-primary-100',
+                'mobileDropdownActiveItemColor' => 'dark:bg-black dark:text-theme-secondary-200 text-theme-secondary-900 bg-theme-primary-50',
             ])
         @endisset
     </nav>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

slight adjustment to the active state of the mobile navbar entries

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
