### PR TITLE
refactor: allow overridden classes on input with prefix

### DIFF
--- a/resources/views/inputs/input-with-prefix.blade.php
+++ b/resources/views/inputs/input-with-prefix.blade.php
@@ -17,10 +17,14 @@
 
         <div
             @class([
-                'input-wrapper input-wrapper-with-prefix',
+                'input-wrapper input-wrapper-with-prefix' => ($wrapperClassOverride ?? null) === null,
+                ($wrapperClassOverride ?? null),
                 'input-text--error' => $errors->has($name),
+                $containerClass ?? null,
             ])
-            x-bind:class="{ 'input-wrapper-with-prefix--dirty': !! isDirty }"
+            @unless ($disableDirtyStyling ?? false)
+                x-bind:class="{ 'input-wrapper-with-prefix--dirty': !! isDirty }"
+            @endunless
         >
             @if ($icon ?? false)
                 @include('ark::inputs.includes.input-prefix-icon', [
@@ -37,7 +41,10 @@
                 'name'           => $name,
                 'errors'         => null,
                 'id'             => $id ?? $name,
-                'inputTypeClass' => 'input-text-with-prefix',
+                'inputTypeClass' => Arr::toCssClasses([
+                    'input-text-with-prefix' => ($fieldClassOverride ?? null) === null,
+                    ($fieldClassOverride ?? null),
+                ]),
                 'inputClass'     => $inputClass ?? '',
                 'noModel'        => $noModel ?? false,
                 'model'          => $model ?? $name,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861mrtzht

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
