### PR TITLE
refactor: allow passing input prefix icon size

### DIFF
--- a/resources/views/inputs/includes/input-prefix-icon.blade.php
+++ b/resources/views/inputs/includes/input-prefix-icon.blade.php
@@ -2,6 +2,7 @@
     'icon',
     'position' => 'right',
     'iconClass' => '',
+    'iconSize' => 'base',
 ])
 
 @php
@@ -13,5 +14,5 @@
 @endphp
 
 <div class="input-prefix-icon {{ $positionClasses }} {{ $iconClass }}">
-    <x-ark-icon :name="$icon" />
+    <x-ark-icon :name="$icon" :size="$iconSize" />
 </div>

--- a/resources/views/inputs/input-with-prefix.blade.php
+++ b/resources/views/inputs/input-with-prefix.blade.php
@@ -30,6 +30,7 @@
                 @include('ark::inputs.includes.input-prefix-icon', [
                     'icon'     => $icon,
                     'position' => 'left',
+                    'iconSize' => 'sm'
                 ])
             @elseif($prefix ?? false)
                 <div @class(['input-prefix', $prefixClass ?? 'bg-theme-primary-50 dark:bg-theme-secondary-800'])>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Needed to allow for a smaller icon on ARKScan

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
