### PR TITLE
refactor: allow dropdown component without button

### DIFF
--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -17,6 +17,7 @@
     'onClose'                => null,
     'disabled'               => false,
     'withPlacement'          => false,
+    'withoutButton'          => false,
 ])
 
 <div
@@ -56,21 +57,23 @@
     @if($wrapperClass) class="{{ $wrapperClass }}" @endif
     @if($dusk) dusk="{{ $dusk }}" @endif
 >
-    <div>
-        <button
-            type="button"
-            :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }}, '{{ $buttonClassClosed }}' : !{{ $dropdownProperty }} }"
-            class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
-            @if($disabled) disabled @else @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif
-            @if($buttonTooltip) data-tippy-content="{{ $buttonTooltip }}" @endif
-        >
-            @if($button ?? false)
-                {{ $button }}
-            @else
-                <x-ark-icon name="ellipsis-vertical" />
-            @endif
-        </button>
-    </div>
+    @unless($withoutButton)
+        <div>
+            <button
+                type="button"
+                :class="{ '{{ $buttonClassExpanded }}' : {{ $dropdownProperty }}, '{{ $buttonClassClosed }}' : !{{ $dropdownProperty }} }"
+                class="flex items-center focus:outline-none dropdown-button transition-default {{ $buttonClass }}"
+                @if($disabled) disabled @else @click="{{ $dropdownProperty }} = !{{ $dropdownProperty }}" @endif
+                @if($buttonTooltip) data-tippy-content="{{ $buttonTooltip }}" @endif
+            >
+                @if($button ?? false)
+                    {{ $button }}
+                @else
+                    <x-ark-icon name="ellipsis-vertical" />
+                @endif
+            </button>
+        </div>
+    @endunless
 
     <div
         x-show="{{ $dropdownProperty }}"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861mru5mf

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
