### PR TITLE
fix: last table cell padding

### DIFF
--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -479,6 +479,11 @@
 .table-container table thead th.last-until-md,
 .table-container table thead th.last-until-md-lg,
 .table-container table thead th.last-until-sm,
+.table-container table tbody td.hoverable-cell.last-cell-sm .table-cell-content,
+.table-container table tbody td.hoverable-cell.last-cell-md .table-cell-content,
+.table-container table tbody td.hoverable-cell.last-cell-md-lg .table-cell-content,
+.table-container table tbody td.hoverable-cell.last-cell-lg .table-cell-content,
+.table-container table tbody td.hoverable-cell.last-cell-xl .table-cell-content,
 .table-container table tbody td.hoverable-cell:last-child .table-cell-content {
     @apply pr-0;
 }
@@ -506,6 +511,7 @@
         content: none;
     }
 
+    .table-container table tbody td.hoverable-cell.last-cell-sm .table-cell-content,
     .table-container table thead th.last-until-sm {
         @apply pr-3;
     }
@@ -529,6 +535,7 @@
         content: none;
     }
 
+    .table-container table tbody td.hoverable-cell.last-cell-md .table-cell-content,
     .table-container table thead th.last-until-md {
         @apply pr-3;
     }
@@ -552,6 +559,7 @@
         content: none;
     }
 
+    .table-container table tbody td.hoverable-cell.last-cell-md-lg .table-cell-content,
     .table-container table thead th.last-until-md-lg {
         @apply pr-3;
     }
@@ -575,6 +583,7 @@
         content: none;
     }
 
+    .table-container table tbody td.hoverable-cell.last-cell-lg .table-cell-content,
     .table-container table thead th.last-until-lg {
         @apply pr-3;
     }
@@ -598,6 +607,7 @@
         content: none;
     }
 
+    .table-container table tbody td.hoverable-cell.last-cell-xl .table-cell-content,
     .table-container table thead th.last-until-xl {
         @apply pr-3;
     }

--- a/resources/assets/css/_tables.css
+++ b/resources/assets/css/_tables.css
@@ -481,7 +481,11 @@
 .table-container table thead th.last-until-sm,
 .table-container table tbody td.hoverable-cell.last-cell-sm .table-cell-content,
 .table-container table tbody td.hoverable-cell.last-cell-md .table-cell-content,
-.table-container table tbody td.hoverable-cell.last-cell-md-lg .table-cell-content,
+.table-container
+    table
+    tbody
+    td.hoverable-cell.last-cell-md-lg
+    .table-cell-content,
 .table-container table tbody td.hoverable-cell.last-cell-lg .table-cell-content,
 .table-container table tbody td.hoverable-cell.last-cell-xl .table-cell-content,
 .table-container table tbody td.hoverable-cell:last-child .table-cell-content {
@@ -511,7 +515,11 @@
         content: none;
     }
 
-    .table-container table tbody td.hoverable-cell.last-cell-sm .table-cell-content,
+    .table-container
+        table
+        tbody
+        td.hoverable-cell.last-cell-sm
+        .table-cell-content,
     .table-container table thead th.last-until-sm {
         @apply pr-3;
     }
@@ -535,7 +543,11 @@
         content: none;
     }
 
-    .table-container table tbody td.hoverable-cell.last-cell-md .table-cell-content,
+    .table-container
+        table
+        tbody
+        td.hoverable-cell.last-cell-md
+        .table-cell-content,
     .table-container table thead th.last-until-md {
         @apply pr-3;
     }
@@ -559,7 +571,11 @@
         content: none;
     }
 
-    .table-container table tbody td.hoverable-cell.last-cell-md-lg .table-cell-content,
+    .table-container
+        table
+        tbody
+        td.hoverable-cell.last-cell-md-lg
+        .table-cell-content,
     .table-container table thead th.last-until-md-lg {
         @apply pr-3;
     }
@@ -583,7 +599,11 @@
         content: none;
     }
 
-    .table-container table tbody td.hoverable-cell.last-cell-lg .table-cell-content,
+    .table-container
+        table
+        tbody
+        td.hoverable-cell.last-cell-lg
+        .table-cell-content,
     .table-container table thead th.last-until-lg {
         @apply pr-3;
     }
@@ -607,7 +627,11 @@
         content: none;
     }
 
-    .table-container table tbody td.hoverable-cell.last-cell-xl .table-cell-content,
+    .table-container
+        table
+        tbody
+        td.hoverable-cell.last-cell-xl
+        .table-cell-content,
     .table-container table thead th.last-until-xl {
         @apply pr-3;
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861mwnpqg

Potentially a breaking change - the last cell when responsive shouldn't have any right padding. This wasn't the case

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
