### PR TITLE
feat: allow html version of tippy tooltip

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -60,7 +60,9 @@ const initTippy = (parentEl = document.body) => {
 
 const destroyTippy = (parentEl = document.body) => {
     parentEl
-        .querySelectorAll("[data-tippy-content], [data-tippy-hover]")
+        .querySelectorAll(
+            "[data-tippy-content], [data-tippy-hover], [data-tippy-html-content]"
+        )
         .forEach((el) => {
             if (!el._tippy) {
                 console.error(
@@ -85,7 +87,8 @@ const destroyOutdatedTippyInstances = () => {
             !!el.parentNode &&
             // The element still has the tippy attribute
             (el.getAttribute("data-tippy-hover") ||
-                el.getAttribute("data-tippy-content"))
+                el.getAttribute("data-tippy-content") ||
+                el.getAttribute("data-tippy-html-content"))
         ) {
             collection.push(instance);
         } else {

--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -41,6 +41,21 @@ const initTippy = (parentEl = document.body) => {
             tippyInstances.push(tippy(el, instanceSettings));
         }
     });
+
+    // For HTML version
+    Array.from(parentEl.querySelectorAll("[data-tippy-html-content]")).forEach(
+        (el) => {
+            const instanceSettings = { allowHTML: true, ...tooltipSettings };
+            instanceSettings.content = (reference) =>
+                reference.dataset.tippyHtmlContent;
+
+            if (el._tippy) {
+                el._tippy.setProps(instanceSettings);
+            } else {
+                tippyInstances.push(tippy(el, instanceSettings));
+            }
+        }
+    );
 };
 
 const destroyTippy = (parentEl = document.body) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Add a html version for tippy tooltips with `data-tippy-html-content`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
