### PR TITLE
refactor: use attribute content when applying tippy

### DIFF
--- a/resources/assets/js/tippy.js
+++ b/resources/assets/js/tippy.js
@@ -33,6 +33,9 @@ const initTippy = (parentEl = document.body) => {
             instanceSettings.trigger = "mouseenter";
             instanceSettings.content = (reference) =>
                 reference.dataset.tippyHover;
+        } else {
+            instanceSettings.content = (reference) =>
+                reference.dataset.tippyContent;
         }
 
         if (el._tippy) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqm6nmv

Fixes an issue where tooltips using `data-tippy-content` don't update the tooltip content/value so changing the fiat on explorer results in using the old tooltip value

Required by https://github.com/ArdentHQ/arkscan/pull/703

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
