### PR TITLE
chore: remove explorer specific phpstan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,6 @@ parameters:
         # MarketSquare
         - ../../../app/App/Console/Playbooks
         - ../../../app/App/Nova/*
-        # Explorer
-        - ../../../app/Console/Playbooks
-        - ../../../app/Console/Commands/RunPlaybookCommand.php
-        - ../../../app/Services/Monitor
     level: 8
     ignoreErrors:
         - '#is not allowed to extend#'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

As a result of https://app.clickup.com/t/86dtc3dmu

It's possible to include a phpstan config file from within another. See [here](https://github.com/ArdentHQ/arkscan/pull/863/commits/bb822f1ed37c5bbfc25eaea0d87f8488ac6e792d#diff-0361f0c81f363476ddc6f44ab36fcbe66ee685d5f4c2a46b054924591544b766)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
