### PR TITLE
refactor: handle overriding currency decimal places

### DIFF
--- a/src/NumberFormatter/Concerns/HasCustomFormatters.php
+++ b/src/NumberFormatter/Concerns/HasCustomFormatters.php
@@ -26,7 +26,7 @@ trait HasCustomFormatters
         $result = $this->formatWithDecimal((float) $value);
 
         if (Str::contains((string) $value, '.')) {
-            $result = number_format((float) ResolveScientificNotation::execute((float) $value), $decimals ?? 8);
+            $result = number_format((float) ResolveScientificNotation::execute((float) $value), $decimals ?? config('currencies.decimals.crypto', 8));
 
             if (Str::contains((string) $result, '.')) {
                 $result = rtrim(rtrim((string) $result, '0'), '.');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

related to https://app.clickup.com/t/86dugrp91

Mainsail will handle 18 decimal places instead of 8, so this is to allow changing that while also remaining backwards compatible

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I provided a screenshot of my changes to the component _(if applicable)_
-   [ ] I regenerated the `icons.html` file and checked if my newly added icon is shown correctly _(if necessary)_
-   [ ] I added an explanation on how to use the component to the readme _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
