### PR TITLE
fix: use proper livewire dispatch for kiosk user deletion

### DIFF
--- a/resources/views/pages/blog/kiosk/users.blade.php
+++ b/resources/views/pages/blog/kiosk/users.blade.php
@@ -58,7 +58,7 @@
                                                 <button
                                                     type="button"
                                                     class="flex items-center space-x-1 text-sm font-medium text-theme-danger-600"
-                                                    @click="window.Livewire.dispatch('triggerUserDelete', {{ $user->id }})"
+                                                    @click="$dispatch('triggerUserDelete', {id: {{ $user->id }}})"
                                                 >
                                                     <x-ark-icon name="trash" size="sm" />
 

--- a/tests/Blog/Feature/Http/Controllers/KioskControllerTest.php
+++ b/tests/Blog/Feature/Http/Controllers/KioskControllerTest.php
@@ -14,6 +14,15 @@ it('can render kiosk', function () {
         ->assertViewIs('ark::pages.blog.kiosk.articles');
 });
 
+it('uses a livewire v3 compatible dispatch payload for article deletion', function () {
+    $article = Article::factory()->create();
+
+    $this->actingAs(User::factory()->create(['two_factor_secret' => 'code']))
+        ->get(route('kiosk.articles'))
+        ->assertOk()
+        ->assertSee(sprintf("\$dispatch('triggerArticleDelete', {id: %d})", $article->id), false);
+});
+
 it('can render an article page', function () {
     $article = Article::factory()->create();
 

--- a/tests/Blog/Feature/Http/Controllers/UserControllerTest.php
+++ b/tests/Blog/Feature/Http/Controllers/UserControllerTest.php
@@ -14,6 +14,15 @@ it('can render user kiosk', function () {
         ->assertViewHas('users', fn ($users) => $users->getCollection()->count() === 2);
 });
 
+it('uses a livewire v3 compatible dispatch payload for user deletion', function () {
+    $other = User::factory()->create();
+
+    $this->actingAs(User::factory()->create(['two_factor_secret' => 'code']))
+        ->get(route('kiosk.users'))
+        ->assertOk()
+        ->assertSee(sprintf("\$dispatch('triggerUserDelete', {id: %d})", $other->id), false);
+});
+
 it('can render a user update page', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
Fixes https://app.clickup.com/t/86dykk9m8

Same issue as #650 but for the users kiosk page — deleting a user throws `Only arrays and Traversables can be unpacked, int given`. Updates the dispatch payload to the Livewire v3 format and adds regression tests for both the users and articles kiosk pages to catch this shape in the rendered output.